### PR TITLE
Use haskell action output for cabal cache path

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -14,16 +14,19 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-haskell@v1
+      id: setup-haskell
       with:
         ghc-version: '8.8.3'
         cabal-version: '3.2'
 
     - name: Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       env:
         cache-name: cache-cabal
       with:
-        path: ~/.cabal
+        path: |
+          ${{ steps.setup-haskell.outputs.cabal-store }}
+          dist-newstyle
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-


### PR DESCRIPTION
actions/cache@v2 supports multiple paths, so you can cache dist-newstyle without duplicating the boilerplate. That speeds up incremental rebuilding if only part of the code is changed.

The path for the cabal-store is cached from the output so that it's correct, regardless of operating system used.