### PR TITLE
Issue 36: ParserGen use specialized syntax

### DIFF
--- a/src/Daedalus/ParserGen/AST.hs
+++ b/src/Daedalus/ParserGen/AST.hs
@@ -1,129 +1,146 @@
 module Daedalus.ParserGen.AST where
 
-import Data.Text(Text)
+-- import Data.Text(Text)
 
 
-import Data.ByteString(ByteString)
-import Data.Word
+-- import Data.ByteString(ByteString)
+-- import Data.Word
 
 import qualified Data.Map as Map
 
 import Daedalus.Type.AST hiding (ppBinder)
 
 
-import Daedalus.Normalise.AST (NType)
+-- import Daedalus.Normalise.AST (NType)
+
+type Annot = [Int]
+
 -- No type variables.
 --data NType = NType (TypeF NType)
 --  deriving (Show)
 
 
 -- Only Value variables
-data NName = NName { nName :: Name } --, nType :: NType }
-  deriving (Eq, Ord)
+-- data NName = NName { nName :: Name } --, nType :: NType }
+--   deriving (Eq, Ord)
 
-instance (Show NName) where
-  show x =
-    case (nameScope (nName x)) of
-      Local str -> show str
-      Unknown str -> show str
-      ModScope _ i -> show i
-
-type Annot = [Int]
-
-data NCExpr =
-    NSetAny
-  | NSetSingle NVExpr
-  | NSetComplement NCExpr
-  | NSetUnion  [NCExpr]
-  | NSetOneOf  ByteString
-  | NSetDiff   NCExpr NCExpr
-  | NSetRange  NVExpr NVExpr
-  | NCCall     NName [NVExpr]
-  | NCLet      NName NVExpr NCExpr
-  | NCFor NName NVExpr NName NVExpr NCExpr
-  deriving (Show)
-
-data NVExpr =
-    NVLet NName NVExpr NVExpr
-  | NCoerce NType NType NVExpr
-  | NNumber Integer NType
-  | NBool   Bool
-  | NNothing NType
-  | NJust NVExpr
-  | NByte   Word8
-  | NStruct [ (Label, NVExpr) ] NType
-  | NUnit
-  | NByteArray ByteString
-  | NArray     [NVExpr] NType
-  | NMapEmpty NType
-  | NIn Label NVExpr NType
-  | NBinOp BinOp NVExpr NVExpr
-  | NUniOp UniOp NVExpr
-  | NSelStruct NVExpr Label NType
-  | NIf        NVExpr NVExpr NVExpr
-  | NVCall     NName [NVExpr]
-  | NVFor NName NVExpr NName NVExpr NVExpr
-  | NVar NName
-  deriving (Show)
-
-type NGExpr = (NGExprCstr, Annot)
-data NGExprCstr =
-    NGPure NVExpr
-  | NLabel Text NGrammar
-  | NGuard NVExpr
-  | NCurrnetStream
-  | NSetStream NVExpr
-  | NStreamLen WithSem NVExpr NVExpr
-  | NStreamOff WithSem NVExpr NVExpr
-
-  | NGetByte WithSem
-  | NMatch WithSem NCExpr
-  | NMatchBytes WithSem NVExpr
-  | NChoice Commit [NGrammar] NType
-  | NOptional Commit NGrammar
-  | NMany WithSem Commit (ManyBounds NVExpr) NGrammar
-  | NEnd
-  | NOffset
-  | NMapLookup WithSem NVExpr NVExpr
-  | NMapInsert WithSem NVExpr NVExpr NVExpr
-  | NCoerceCheck WithSem NType NType NVExpr
-  | NSelUnion WithSem NVExpr Label NType
-  | NSelJust WithSem NVExpr NType
-  | NGFor NName NVExpr NName NVExpr NGrammar
-  | NGMap NName NVExpr NGrammar
-  | NGCall NName [NVExpr]
-  | NGErrorMode Commit NGrammar
-  | NGFail (Maybe NVExpr) NType
-  deriving (Show)
-
-type NGrammar = (NGrammarCstr, Annot)
-data NGrammarCstr =
-  NPure NVExpr | NBind (Maybe NName) NGExpr NGrammar
-  deriving (Show)
-
-type NDeclBody = (NDeclBodyCstr, Annot)
-data NDeclBodyCstr  =
-    NCDecl NCExpr
-  | NVDecl NVExpr
-  | NGDecl NGrammar
-  | NExtern
-  deriving (Show)
-
-type NDecl = (NDeclCstr, Annot)
-data NDeclCstr = NDecl { nDeclName     :: !Name
-                       -- , nDeclCtrs     :: ![Constraint]
-                       , nDeclParams   :: ![NName]
-                       , nDeclType     :: NType
-                       , nDeclDef      :: !NDeclBody
-                       }
-  deriving (Show)
+-- instance (Show NName) where
+--   show x =
+--     case (nameScope (nName x)) of
+--       Local str -> show str
+--       Unknown str -> show str
+--       ModScope _ i -> show i
 
 
-type GblAlloc = Map.Map Name NDecl
+-- data NCExpr =
+--     NSetAny
+--   | NSetSingle NVExpr
+--   | NSetComplement NCExpr
+--   | NSetUnion  [NCExpr]
+--   | NSetOneOf  ByteString
+--   | NSetDiff   NCExpr NCExpr
+--   | NSetRange  NVExpr NVExpr
+--   | NCCall     NName [NVExpr]
+--   | NCLet      NName NVExpr NCExpr
+--   | NCFor NName NVExpr NName NVExpr NCExpr
+--   deriving (Show)
+
+-- data NVExpr =
+--     NVLet NName NVExpr NVExpr
+--   | NCoerce NType NType NVExpr
+--   | NNumber Integer NType
+--   | NBool   Bool
+--   | NNothing NType
+--   | NJust NVExpr
+--   | NByte   Word8
+--   | NStruct [ (Label, NVExpr) ] NType
+--   | NUnit
+--   | NByteArray ByteString
+--   | NArray     [NVExpr] NType
+--   | NMapEmpty NType
+--   | NIn Label NVExpr NType
+--   | NBinOp BinOp NVExpr NVExpr
+--   | NUniOp UniOp NVExpr
+--   | NSelStruct NVExpr Label NType
+--   | NIf        NVExpr NVExpr NVExpr
+--   | NVCall     NName [NVExpr]
+--   | NVFor NName NVExpr NName NVExpr NVExpr
+--   | NVar NName
+--   deriving (Show)
+
+-- type NGExpr = (NGExprCstr, Annot)
+-- data NGExprCstr =
+--     NGPure NVExpr
+--   | NLabel Text NGrammar
+--   | NGuard NVExpr
+--   | NCurrnetStream
+--   | NSetStream NVExpr
+--   | NStreamLen WithSem NVExpr NVExpr
+--   | NStreamOff WithSem NVExpr NVExpr
+
+--   | NGetByte WithSem
+--   | NMatch WithSem NCExpr
+--   | NMatchBytes WithSem NVExpr
+--   | NChoice Commit [NGrammar] NType
+--   | NOptional Commit NGrammar
+--   | NMany WithSem Commit (ManyBounds NVExpr) NGrammar
+--   | NEnd
+--   | NOffset
+--   | NMapLookup WithSem NVExpr NVExpr
+--   | NMapInsert WithSem NVExpr NVExpr NVExpr
+--   | NCoerceCheck WithSem NType NType NVExpr
+--   | NSelUnion WithSem NVExpr Label NType
+--   | NSelJust WithSem NVExpr NType
+--   | NGFor NName NVExpr NName NVExpr NGrammar
+--   | NGMap NName NVExpr NGrammar
+--   | NGCall NName [NVExpr]
+--   | NGErrorMode Commit NGrammar
+--   | NGFail (Maybe NVExpr) NType
+--   deriving (Show)
+
+-- type NGrammar = (NGrammarCstr, Annot)
+-- data NGrammarCstr =
+--   NPure NVExpr | NBind (Maybe NName) NGExpr NGrammar
+--   deriving (Show)
+
+-- type NDeclBody = (NDeclBodyCstr, Annot)
+-- data NDeclBodyCstr  =
+--     NCDecl NCExpr
+--   | NVDecl NVExpr
+--   | NGDecl NGrammar
+--   | NExtern
+--   deriving (Show)
+
+-- type NDecl = (NDeclCstr, Annot)
+-- data NDeclCstr = NDecl { nDeclName     :: !Name
+--                        -- , nDeclCtrs     :: ![Constraint]
+--                        , nDeclParams   :: ![NName]
+--                        , nDeclType     :: NType
+--                        , nDeclDef      :: !NDeclBody
+--                        }
+--   deriving (Show)
+
+
+-- type GblAlloc = Map.Map Name NDecl
+
+-- data CorV =
+--     ClassExpression NCExpr
+--   | ValueExpression NVExpr
+--   deriving (Show)
+
+-- type GblFuns = Map.Map Name ([NName], CorV)
+
+type NCExpr = TC (SourceRange, Annot) Class
+type NVExpr = TC (SourceRange, Annot) Value
+
+
+type GblAlloc = Map.Map Name (TCModule (SourceRange, Annot))
 
 data CorV =
-    ClassExpression NCExpr
-  | ValueExpression NVExpr
+    ClassExpr (TC (SourceRange, Annot) Class)
+  | ValueExpr (TC (SourceRange, Annot) Value)
   deriving (Show)
 
-type GblFuns = Map.Map Name ([NName], CorV)
+type GblFuns = Map.Map Name ([Name], CorV)
+
+type GblGrammar = Map.Map Name (TCDecl (SourceRange, Annot))

--- a/src/Daedalus/ParserGen/Compile.hs
+++ b/src/Daedalus/ParserGen/Compile.hs
@@ -1,16 +1,17 @@
 {-# Language GADTs, DataKinds, ExistentialQuantification, RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# language FlexibleContexts #-}
 
-module Daedalus.ParserGen.Compile ( module Daedalus.ParserGen.Compile ) where
 
+module Daedalus.ParserGen.Compile where
+
+import Data.Word
+import qualified Data.ByteString as BS
 import qualified Data.Map as Map
 import Data.Maybe (fromJust)
 import Data.List (isInfixOf)
 
-
-import Daedalus.AST (Name(..))
-import Daedalus.Normalise.AST
-import Daedalus.Type.AST (WithSem(..))
-import Daedalus.AST (ManyBounds(..), Commit(..))
+import Daedalus.Type.AST
 
 -- import Debug.Trace
 
@@ -18,179 +19,292 @@ import qualified Daedalus.ParserGen.AST as PAST
 import Daedalus.ParserGen.Action
 import Daedalus.ParserGen.Aut
 
+
 ------- 1 Allocate States
 
-allocate :: a -> Int -> Int -> ((a, [Int]), Int)
+allocate :: a -> Int -> Int -> ((a, PAST.Annot), Int)
 allocate p start num =
   let newlast = start + num
   in ((p, [(start+1) .. newlast]), newlast)
 
-nameToName :: NName -> PAST.NName
-nameToName n =
-  PAST.NName {PAST.nName = nName n} --, PAST.nType = nType v}
 
-
-idCExpr :: NCExpr -> PAST.NCExpr
+idCExpr :: Show a => TC a Class -> TC (a, PAST.Annot) Class
 idCExpr cexpr =
-  case cexpr of
-    NSetAny -> PAST.NSetAny
-    NSetSingle e1 -> PAST.NSetSingle (idVExpr e1)
-    NSetComplement e1 -> PAST.NSetComplement (idCExpr e1)
-    NSetUnion  le -> PAST.NSetUnion (map idCExpr le)
-    NSetOneOf bs -> PAST.NSetOneOf bs
-    NSetRange e1 e2 -> PAST.NSetRange (idVExpr e1) (idVExpr e2)
-    NCCall n lst -> PAST.NCCall (nameToName n) (map idVExpr lst)
-    _ -> error ("TODO: " ++ show cexpr)
+  annotExpr ((texprAnnot cexpr), []) subexpr
+  where
+    subexpr =
+      case texprValue cexpr of
+        TCSetAny -> TCSetAny
+        TCSetSingle e1 -> TCSetSingle (idVExpr e1)
+        TCSetComplement e1 -> TCSetComplement (idCExpr e1)
+        TCSetUnion  le -> TCSetUnion (map idCExpr le)
+        TCSetOneOf bs -> TCSetOneOf bs
+        TCSetRange e1 e2 -> TCSetRange (idVExpr e1) (idVExpr e2)
+        TCCall n [] lst -> TCCall n [] (map subArg lst)
+        TCCall _ _ _    -> error "Saw a function call with non-empty type args"
+        _ -> error ("TODO: " ++ show cexpr)
 
-idVExpr :: NVExpr -> PAST.NVExpr
+    subArg arg =
+      case arg of
+        ValArg a -> ValArg $ idVExpr a
+        _ -> error "value argument expected"
+
+idVExpr :: Show a => TC a Value -> TC (a, PAST.Annot) Value
 idVExpr vexpr =
-  case vexpr of
-    NCoerce ty1 ty2 e1 -> PAST.NCoerce ty1 ty2 (idVExpr e1)
-    NNumber i t -> PAST.NNumber i t
-    NBool b -> PAST.NBool b
-    NNothing t -> PAST.NNothing t
-    NJust e -> PAST.NJust (idVExpr e)
-    NByte w -> PAST.NByte w
-    NStruct s t -> PAST.NStruct (map (\ (s',e) -> (s', idVExpr e)) s) t
-    NUnit -> PAST.NUnit
-    NByteArray ba -> PAST.NByteArray ba
-    NArray     l t -> PAST.NArray (map idVExpr l) t
-    NMapEmpty t -> PAST.NMapEmpty t
-    NIn lbl e lst -> PAST.NIn lbl (idVExpr e) lst
-    NBinOp op e1 e2 _ -> PAST.NBinOp op (idVExpr e1) (idVExpr e2)
-    NUniOp op e1 -> PAST.NUniOp op (idVExpr e1)
-    NSelStruct e n t -> PAST.NSelStruct (idVExpr e) n t
-    NIf e1 e2 e3 -> PAST.NIf (idVExpr e1) (idVExpr e2) (idVExpr e3)
-    NVCall n lst -> PAST.NVCall (nameToName n) (map idVExpr lst)
-    NVFor n e1 Nothing n1 e2 e3 -> PAST.NVFor (nameToName n) (idVExpr e1) (nameToName n1) (idVExpr e2) (idVExpr e3)
-    NVar v ->
-      let av = nameToName v
-      in PAST.NVar av
-    _ -> error ("TODO: " ++ show vexpr)
+  annotExpr ((texprAnnot vexpr), []) subexpr
+  where
+    subexpr =
+      case texprValue vexpr of
+        TCCoerce ty1 ty2 e1 -> TCCoerce ty1 ty2 (idVExpr e1)
+        TCNumber i t -> TCNumber i t
+        TCBool b -> TCBool b
+        TCNothing t -> TCNothing t
+        TCJust e -> TCJust (idVExpr e)
+        TCByte w -> TCByte w
+        TCStruct s t -> TCStruct (map (\ (s',e) -> (s', idVExpr e)) s) t
+        TCUnit -> TCUnit
+        TCByteArray ba -> TCByteArray ba
+        TCArray lst t -> TCArray (map idVExpr lst) t
+        TCMapEmpty t -> TCMapEmpty t
+        TCIn lbl e lst -> TCIn lbl (idVExpr e) lst
+        TCBinOp op e1 e2 t -> TCBinOp op (idVExpr e1) (idVExpr e2) t
+        TCUniOp op e1 -> TCUniOp op (idVExpr e1)
+        TCSelStruct e n t -> TCSelStruct (idVExpr e) n t
+        TCIf e1 e2 e3 -> TCIf (idVExpr e1) (idVExpr e2) (idVExpr e3)
+        TCCall n [] lst -> TCCall n [] (map subArg lst)
+        TCCall _ _ _   -> error "Saw a function call with non-empty type args"
+        -- TCFor n e1 Nothing n1 e2 e3 -> TCVFor n (idVExpr e1) n1 (idVExpr e2) (idVExpr e3)
+        TCFor lp ->
+          case loopFlav lp of
+            LoopMap -> TCFor $
+              Loop{ loopFlav = LoopMap
+                  , loopKName = loopKName lp
+                  , loopElName = loopElName lp
+                  , loopCol = idVExpr (loopCol lp)
+                  , loopBody = idVExpr (loopBody lp)
+                  , loopType = loopType lp
+                  }
+            Fold n1 e1 ->
+              TCFor $
+              Loop{ loopFlav = Fold n1 (idVExpr e1)
+                  , loopKName = loopKName lp
+                  , loopElName = loopElName lp
+                  , loopCol = idVExpr (loopCol lp)
+                  , loopBody = idVExpr (loopBody lp)
+                  , loopType = loopType lp
+                  }
 
-convertManyBounds :: ManyBounds NVExpr -> ManyBounds PAST.NVExpr
+        TCVar v -> TCVar v
+        _ -> error ("TODO: " ++ show vexpr)
+
+    subArg arg =
+      case arg of
+        ValArg a -> ValArg $ idVExpr a
+        _ -> error "value argument expected"
+
+
+convertManyBounds :: Show a => ManyBounds (TC a Value) -> ManyBounds (TC (a, PAST.Annot) Value)
 convertManyBounds b = fmap idVExpr b
 
-allocGExpr :: Int -> NGExpr -> (PAST.NGExpr, Int)
-allocGExpr n gexpr =
-  case gexpr of
-    NGPure e ->
-      let ae = idVExpr e
-      in allocate (PAST.NGPure ae) n 2
-    NLabel l g ->
-      let (ag, n1) = allocGram n g
-      in allocate (PAST.NLabel l ag) n1 0
-    NGuard e ->
-      let ae = idVExpr e
-      in allocate (PAST.NGuard ae) n 2
-    NCurrnetStream ->
-      allocate (PAST.NCurrnetStream) n 2
-    NSetStream e1 ->
-      let ae1 = idVExpr e1
-      in allocate (PAST.NSetStream ae1) n 2
-    NStreamLen ws e1 e2 ->
-      let ae1 = idVExpr e1
-          ae2 = idVExpr e2
-      in allocate (PAST.NStreamLen ws ae1 ae2) n 2
-    NStreamOff ws e1 e2 ->
-      let ae1 = idVExpr e1
-          ae2 = idVExpr e2
-      in allocate (PAST.NStreamOff ws ae1 ae2) n 2
-    NGetByte ws ->
-      allocate (PAST.NGetByte ws) n 2
-    NMatch ws cexpr ->
-      let acexpr = idCExpr cexpr
-      in allocate (PAST.NMatch ws acexpr) n 2
-    NMatchBytes ws vexpr ->
-      let ae = idVExpr vexpr
-      in
-        case getByteArray ae of
-          Nothing -> allocate (PAST.NMatchBytes ws ae) n 2
-          Just str -> allocate (PAST.NMatchBytes ws ae) n (2 * (length str) + 2)
-    NChoice c lst t ->
-      let step g (ags, n') = let (ag, n1) = allocGram n' g
-                             in (ag:ags, n1)
-          (alst, ns) = foldr step ([], n) lst
-      in allocate (PAST.NChoice c alst t) ns 2
-    NOptional c e1 ->
-      let (ae1, n1) = allocGram n e1
-      in allocate (PAST.NOptional c ae1) n1 2
-    NMany ws c bounds e1 ->
-      let (ae1, n1) = allocGram n e1
-      in allocate (PAST.NMany ws c (convertManyBounds bounds) ae1) n1 7
-    NEnd -> allocate (PAST.NEnd) n 2
-    NOffset -> allocate (PAST.NOffset) n 2
-    NMapLookup ws e1 e2 ->
-      let ae1 = idVExpr e1
-          ae2 = idVExpr e2
-      in allocate (PAST.NMapLookup ws ae1 ae2) n 2
-    NMapInsert ws e1 e2 e3 ->
-      let ae1 = idVExpr e1
-          ae2 = idVExpr e2
-          ae3 = idVExpr e3
-      in allocate (PAST.NMapInsert ws ae1 ae2 ae3) n 2
-    NCoerceCheck ws t1 t2 e1 ->
-      let ae1 = idVExpr e1
-      in allocate (PAST.NCoerceCheck ws t1 t2 ae1) n 2
-    NSelUnion ws e1 lbl ty ->
-      let ae1 = idVExpr e1
-      in allocate (PAST.NSelUnion ws ae1 lbl ty) n 2
-    NSelJust ws e1 ty ->
-      let ae1 = idVExpr e1
-      in allocate (PAST.NSelJust ws ae1 ty) n 2
-    NGFor nname1 e1 Nothing nname2 e2 gram ->
-      let (agram, n1) = allocGram n gram
-          ae1 = idVExpr e1
-          ae2 = idVExpr e2
-      in allocate (PAST.NGFor (nameToName nname1) ae1 (nameToName nname2) ae2 agram) n1 3
-    NGMap Nothing nname1 e1 gram ->
-      let (agram, n1) = allocGram n gram
-          ae1 = idVExpr e1
-      in allocate (PAST.NGMap (nameToName nname1) ae1 agram) n1 3
-    NGCall nname le ->
-      let ale = map idVExpr le
-      in allocate (PAST.NGCall (nameToName nname) ale) n 2
-    NGErrorMode c e1 ->
-      let (ae1, n1) = allocGram n e1
-      in allocate (PAST.NGErrorMode c ae1) n1 2
-    NGFail e1 t ->
-      let ae1 = maybe Nothing (\ e -> Just $ idVExpr e) e1
-      in allocate (PAST.NGFail ae1 t) n 2
-    x -> error ("TODO:"++ show x)
+getByteArray2 :: TC a Value -> Maybe [Word8]
+getByteArray2 e =
+  case texprValue e of
+    TCByteArray w -> Just (BS.unpack w)
+    _ -> Nothing
 
-allocGram :: Int -> NGrammar -> (PAST.NGrammar, Int)
+
+allocGExpr :: Show a => Int -> TC a Grammar -> (TC (a, PAST.Annot) Grammar, Int)
+allocGExpr n gexpr =
+  (annotExpr ((texprAnnot gexpr), states) subexpr, subexpr_n)
+  where
+    ((subexpr, states), subexpr_n) =
+      case texprValue gexpr of
+        TCPure e ->
+          let ae = idVExpr e
+          in allocate (TCPure ae) n 2
+        TCLabel l g ->
+          let (ag, n1) = allocGram n g
+          in allocate (TCLabel l ag) n1 0
+        TCGuard e ->
+          let ae = idVExpr e
+          in allocate (TCGuard ae) n 2
+        TCCurrentStream ->
+          allocate (TCCurrentStream) n 2
+        TCSetStream e1 ->
+          let ae1 = idVExpr e1
+          in allocate (TCSetStream ae1) n 2
+        TCStreamLen ws e1 e2 ->
+          let ae1 = idVExpr e1
+              ae2 = idVExpr e2
+          in allocate (TCStreamLen ws ae1 ae2) n 2
+        TCStreamOff ws e1 e2 ->
+          let ae1 = idVExpr e1
+              ae2 = idVExpr e2
+          in allocate (TCStreamOff ws ae1 ae2) n 2
+        TCGetByte ws ->
+          allocate (TCGetByte ws) n 2
+        TCMatch ws cexpr ->
+          let acexpr = idCExpr cexpr
+          in allocate (TCMatch ws acexpr) n 2
+        TCMatchBytes ws vexpr ->
+          let ae = idVExpr vexpr
+          in
+            case getByteArray2 ae of
+              Nothing -> allocate (TCMatchBytes ws ae) n 2
+              Just str -> allocate (TCMatchBytes ws ae) n (2 * (length str) + 2)
+        TCChoice c lst t ->
+          let step g (ags, n') = let (ag, n1) = allocGram n' g
+                                 in (ag:ags, n1)
+              (alst, ns) = foldr step ([], n) lst
+          in allocate (TCChoice c alst t) ns 2
+        TCOptional c e1 ->
+          let (ae1, n1) = allocGram n e1
+          in allocate (TCOptional c ae1) n1 2
+        TCMany ws c bounds e1 ->
+          let (ae1, n1) = allocGram n e1
+          in allocate (TCMany ws c (convertManyBounds bounds) ae1) n1 7
+        TCEnd -> allocate (TCEnd) n 2
+        TCOffset -> allocate (TCOffset) n 2
+        TCMapLookup ws e1 e2 ->
+          let ae1 = idVExpr e1
+              ae2 = idVExpr e2
+          in allocate (TCMapLookup ws ae1 ae2) n 2
+        TCMapInsert ws e1 e2 e3 ->
+          let ae1 = idVExpr e1
+              ae2 = idVExpr e2
+              ae3 = idVExpr e3
+          in allocate (TCMapInsert ws ae1 ae2 ae3) n 2
+        TCCoerceCheck ws t1 t2 e1 ->
+          let ae1 = idVExpr e1
+          in allocate (TCCoerceCheck ws t1 t2 ae1) n 2
+        TCSelUnion ws e1 lbl ty ->
+          let ae1 = idVExpr e1
+          in allocate (TCSelUnion ws ae1 lbl ty) n 2
+        TCSelJust ws e1 ty ->
+          let ae1 = idVExpr e1
+          in allocate (TCSelJust ws ae1 ty) n 2
+        TCFor lp ->
+          case loopFlav lp of
+            Fold x e ->
+              let gram = loopBody lp
+                  e1 = e
+                  e2 = loopCol lp
+                  (agram, n1) = allocGram n gram
+                  ae1 = idVExpr e1
+                  ae2 = idVExpr e2
+                  forContent = Loop
+                      { loopFlav = Fold x ae1
+                      , loopKName = loopKName lp
+                      , loopElName = loopElName lp
+                      , loopCol = ae2
+                      , loopBody = agram
+                      , loopType = loopType lp
+                      }
+              in
+                allocate (TCFor forContent) n1 3
+
+            LoopMap ->
+              let gram = loopBody lp
+                  e1 = loopCol lp
+                  (agram, n1) = allocGram n gram
+                  ae1 = idVExpr e1
+                  forContent = Loop
+                      { loopFlav = LoopMap
+                      , loopKName = loopKName lp
+                      , loopElName = loopElName lp
+                      , loopCol = ae1
+                      , loopBody = agram
+                      , loopType = loopType lp
+                      }
+              in allocate (TCFor forContent) n1 3
+        TCCall name [] le ->
+          let ale = map subArg le
+          in allocate (TCCall name [] ale) n 2
+        TCCall _ _ _   -> error "Saw a function call with non-empty type args"
+        TCErrorMode c e1 ->
+          let (ae1, n1) = allocGram n e1
+          in allocate (TCErrorMode c ae1) n1 2
+        TCFail e1 t ->
+          let ae1 = maybe Nothing (\ e -> Just $ idVExpr e) e1
+          in allocate (TCFail ae1 t) n 2
+        x -> error ("TODO: " ++ show x)
+
+    subArg arg =
+      case arg of
+        ValArg a -> ValArg $ idVExpr a
+        _ -> error "value argument expected"
+
+
+allocGram :: forall a. Show a => Int -> TC a Grammar -> (TC (a, PAST.Annot) Grammar, Int)
 allocGram n gram =
-  let allocBindList n1 gr =
-        case gr of
-          NBind mname gexpr gram1 ->
-            let (agexpr, n2) = allocGExpr n1 gexpr
-                (agram1, n3) = allocBindList n2 gram1
-                aname = case mname of
-                          Nothing -> Nothing
-                          Just name -> Just (nameToName name)
-            in allocate (PAST.NBind aname agexpr agram1) n3 2
-          NPure vexpr ->
-            let avexpr = idVExpr vexpr
-            in allocate (PAST.NPure avexpr) n1 2
+  let
+    allocBindList :: Int -> TC a Grammar -> (TC (a, PAST.Annot) Grammar, Int)
+    allocBindList n1 gr =
+      case texprValue gr of
+        TCDo _ _ _ -> allocDo n1 gr
+        TCPure _ -> allocDo n1 gr
+        _ -> allocGExpr n1 gr
+      --trace ("ALLOC GRAM:" ++ show gr) $
+      -- (annotExpr ((texprAnnot gr), states) subexpr, subexpr_n)
+      -- where
+      --   ((subexpr, states), subexpr_n) =
+    allocDo n1 gr =
+      case texprValue gr of
+        TCDo name gexpr gram1 ->
+          let (agexpr, n2) = allocGram n1 gexpr
+              (agram1, n3) = allocDo n2 gram1
+              ((subexpr, states), subexpr_n) = allocate (TCDo name agexpr agram1) n3 2
+          in (annotExpr ((texprAnnot gr), states) subexpr, subexpr_n)
+        TCPure vexpr ->
+          let avexpr = idVExpr vexpr
+              ((subexpr, states), subexpr_n) = allocate (TCPure avexpr) n1 2
+          in (annotExpr ((texprAnnot gr), states) subexpr, subexpr_n)
+             -- x -> error ("broken invariant: only TCDo  or TCPure: " ++ show x)
+        _ ->
+          let (ag,n2) = allocGExpr (n1+2) gr
+              subannot = texprAnnot ag
+          in (annotExpr (fst subannot, (snd subannot)++[n1+1, n1+2]) (texprValue ag), n2)
+
   in
     -- Two states are reserved for the top-level of binds and they are
     -- placed at the end of the list
-    let ((ag, lst), n1) = allocBindList (n+2) gram in
-    ((ag, lst++[n+1, n+2]), n1)
+    let (ag, n1) = allocBindList (n+2) gram
+        subannot = texprAnnot ag
+    in
+    (annotExpr (fst subannot, (snd subannot)++[n+1, n+2]) (texprValue ag), n1)
 
-allocDeclBody :: Int -> NDeclBody -> (PAST.NDeclBody, Int)
-allocDeclBody n d =
-  case d of
-    NCDecl e ->
-      let ae = idCExpr e
-      in allocate (PAST.NCDecl ae) n 2
-    NVDecl e ->
-      let ae = idVExpr e
-      in allocate (PAST.NVDecl ae) n 2
-    NGDecl e ->
-      let (ae, n1) = allocGram n e
-      in allocate (PAST.NGDecl ae) n1 2
-    NExtern -> allocate (PAST.NExtern) n 2
+
+allocDeclBody :: Show a => Int -> TCDecl a -> (TCDecl (a, PAST.Annot), Int)
+allocDeclBody n _decl@(TCDecl {..}) =
+  let
+    mkBody :: forall a k. Show a => Context k -> TCDeclDef a k -> (TCDeclDef (a, PAST.Annot) k, PAST.Annot, Int)
+    mkBody AClass (Defined tc) =
+      let ae = idCExpr tc
+          ((aae, lst), lastSt) = allocate ae n 2
+      in (Defined aae, lst, lastSt)
+    mkBody AValue (Defined tc) =
+      let ae = idVExpr tc
+          ((aae, lst), lastSt) = allocate ae n 2
+      in (Defined aae, lst, lastSt)
+    mkBody AGrammar (Defined tc) =
+      let (ae, n1) = allocGram n tc
+          ((aae, lst), lastSt) = allocate ae n1 2
+      in (Defined aae, lst, lastSt)
+    mkBody _ (ExternDecl _) =
+      error "TCExtern not handled"
+
+    (ne, lstAnnot, lastState) = mkBody tcDeclCtxt tcDeclDef
+    eAnnot =
+      TCDecl
+      { tcDeclName = tcDeclName
+      , tcDeclTyParams = tcDeclTyParams
+      , tcDeclCtrs = tcDeclCtrs
+      , tcDeclParams = tcDeclParams
+      , tcDeclDef = ne
+      , tcDeclCtxt = tcDeclCtxt
+      , tcDeclAnnot = (tcDeclAnnot, lstAnnot)
+      }
+  in (eAnnot, lastState)
 
 globalStartState :: State
 globalStartState = 1
@@ -198,92 +312,174 @@ globalStartState = 1
 globalFinalState :: State
 globalFinalState = 0
 
+allocTCModule :: Show a => Int -> TCModule a -> (TCModule (a, PAST.Annot), Int)
+allocTCModule n _tc@(TCModule{..}) =
+  let (n1, atc) = foldl fRec (n,[]) tcModuleDecls
+      -- annotTCModule :: TCModule (a, PAST.Annot)
+      annotTCModule =
+        TCModule
+        { tcModuleName = tcModuleName
+        , tcModuleImports = tcModuleImports
+        , tcModuleTypes = tcModuleTypes
+        , tcModuleDecls = reverse atc
+        }
 
-allocStates :: [NDecl] -> PAST.GblAlloc
-allocStates decls =
-  fst $ foldr f (Map.empty, globalStartState) decls
+  in (annotTCModule, n1)
   where
-    f d (lst, n) =
-      let (abody, n1) = allocDeclBody n (nDeclDef d)
-          iname = nDeclName d
-          dd = PAST.NDecl { PAST.nDeclName=iname,
-                            PAST.nDeclParams=map nameToName (nDeclParams d),
-                            PAST.nDeclType=nDeclType d,
-                            PAST.nDeclDef=abody }
-          moreStates = 2
-          ad :: PAST.NDecl
-          (ad, lastn) = allocate dd n1 moreStates
-      in  (Map.insert iname ad lst, lastn)
+    fRec (currN, acc) decl =
+      case decl of
+        NonRec d ->
+          let (adecl, n1) =  allocDeclBody currN d
+          in (n1, NonRec adecl : acc)
+
+        MutRec ds -> -- erasing the dependency analysis
+          let (n1, ads) = foldl f (currN, []) ds
+          in (n1, (MutRec $ reverse ads) : acc)
+    f (currN, acc) d =
+      let (adecl, n1) = allocDeclBody currN d
+      in (n1, adecl : acc)
 
 
-systemToFunctions :: Map.Map Name PAST.NDecl -> PAST.GblFuns
+
+allocStates :: [TCModule SourceRange] -> PAST.GblAlloc
+allocStates decls =
+  let (_lastSt, lstMod) =
+        foldl (
+        \ (b,acc) a ->
+          let (allocMod, st) = allocTCModule b a in (st, allocMod : acc))
+        (globalStartState, []) decls
+  in
+    foldl fRec Map.empty lstMod
+  where
+    fRec m (TCModule{..}) =
+      let newM = foldl fDecl m tcModuleDecls
+      in newM
+
+      where
+        -- the fields of `TCModule` are carried down to every `TDecl`
+        fDecl localM decl =
+          case decl of
+            NonRec d ->
+              let uniModule =
+                    TCModule { tcModuleName = tcModuleName
+                             , tcModuleImports = tcModuleImports
+                             , tcModuleTypes = tcModuleTypes
+                             , tcModuleDecls = [ NonRec d ]
+                             }
+              in  (Map.insert (tcDeclName d) uniModule localM)
+            MutRec ds ->
+              let mres = foldl f localM ds
+              in mres
+
+        f localM decl =
+          let uniModule =
+                TCModule { tcModuleName = tcModuleName
+                         , tcModuleImports = tcModuleImports
+                         , tcModuleTypes = tcModuleTypes
+                         , tcModuleDecls = [ NonRec decl ]
+                         }
+          in
+            Map.insert (tcDeclName decl) uniModule localM
+
+
+paramToName :: Param -> Name
+paramToName param =
+  case param of
+    ValParam v -> tcName v
+    ClassParam v -> tcName v
+    GrammarParam v -> tcName v
+
+argToValue :: Arg a -> TC a Value
+argToValue param =
+  case param of
+    ValArg v -> v
+    ClassArg _ -> error "Class is not a Value"
+    GrammarArg _ -> error "Grammar is not a Value"
+
+
+systemToFunctions :: PAST.GblAlloc -> PAST.GblFuns
 systemToFunctions m =
-  Map.map buildFunSpec (Map.filter onlyValue m)
-  where onlyValue (a, _) =
-          case fst (PAST.nDeclDef a) of
-            PAST.NCDecl _ -> True
-            PAST.NVDecl _ -> True
-            PAST.NGDecl _ -> False
-            PAST.NExtern  -> True -- error ("TODO: NExtern not handled yet")
-        buildFunSpec (a, _) =
-          case fst (PAST.nDeclDef a) of
-            PAST.NCDecl v -> (PAST.nDeclParams a, PAST.ClassExpression v)
-            PAST.NVDecl v -> (PAST.nDeclParams a, PAST.ValueExpression v)
-            _ -> error "can only be a Value Declaration or Class Declaration"
+  Map.map buildFunSpec
+  (Map.filter onlyValue m)
+
+  where
+    onlyValue :: TCModule (SourceRange, PAST.Annot) -> Bool
+    onlyValue (TCModule {tcModuleDecls = [ NonRec (TCDecl {tcDeclCtxt = AClass, tcDeclDef = Defined _}) ]}) =
+      True
+    onlyValue (TCModule {tcModuleDecls = [ NonRec (TCDecl {tcDeclCtxt = AValue, tcDeclDef = Defined _}) ]}) =
+      True
+    onlyValue (TCModule {tcModuleDecls = [ NonRec (TCDecl {tcDeclCtxt = AGrammar, tcDeclDef = Defined _}) ]}) =
+      False
+    onlyValue (TCModule {tcModuleDecls = [ NonRec (TCDecl {tcDeclCtxt = AGrammar, tcDeclDef = ExternDecl _}) ]}) =
+      True -- error ("TODO: NExtern not handled yet")
+    onlyValue (TCModule {tcModuleDecls = _}) =
+      error "broken invariant: more than one declaration"
+
+    buildFunSpec :: TCModule (SourceRange, PAST.Annot) -> ([Name], PAST.CorV)
+    buildFunSpec (TCModule {tcModuleDecls = [ NonRec decl@(TCDecl {tcDeclCtxt = AClass, tcDeclDef = Defined v}) ]}) =
+      (map paramToName (tcDeclParams decl), PAST.ClassExpr v)
+    buildFunSpec (TCModule {tcModuleDecls = [ NonRec decl@(TCDecl {tcDeclCtxt = AValue, tcDeclDef = Defined v}) ]}) =
+      (map paramToName (tcDeclParams decl), PAST.ValueExpr v)
+    buildFunSpec (TCModule {tcModuleDecls = _}) =
+      error "broken invariant: more than one declaration"
 
 
-type GblGrammar = Map.Map Name PAST.NDecl
-
-systemToGrammars :: Map.Map Name PAST.NDecl -> GblGrammar
+systemToGrammars :: PAST.GblAlloc -> PAST.GblGrammar
 systemToGrammars m =
-  Map.filter f m
-  where f (a,_) = case fst (PAST.nDeclDef a) of
-                PAST.NCDecl _ -> False
-                PAST.NVDecl _ -> False
-                PAST.NGDecl _ -> True
-                PAST.NExtern  -> True -- error ("TODO: NExtern not handled yet")
+  Map.map g (Map.filter f m)
+  where f (TCModule {tcModuleDecls = [ NonRec (TCDecl {tcDeclCtxt = AGrammar, tcDeclDef = Defined _}) ]}) =
+          True
+        f _ = False
+
+        g :: TCModule (SourceRange, PAST.Annot) -> (TCDecl (SourceRange, PAST.Annot))
+        g (TCModule {tcModuleDecls = [ NonRec decl@(TCDecl {tcDeclCtxt = AGrammar, tcDeclDef = Defined _}) ]}) =
+          decl
+        g _ = error "broken invariant"
+
+
 
 
 --- 2. Build the Automaton
 
-genGExpr :: GblGrammar -> PAST.NGExpr -> MapAut
-genGExpr gbl (e, st) =
-  case e of
-    PAST.NGPure e1 ->
+genGExpr :: PAST.GblGrammar -> TC (SourceRange, PAST.Annot) Grammar -> MapAut
+genGExpr gbl e =
+  let st = snd (texprAnnot e) in
+  case texprValue e of
+    TCPure e1 ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [(n1, UniChoice (SAct (EvalPure e1), n2))]) n2
-    PAST.NLabel _ g -> -- TODO: ignore the Label case
+    TCLabel _ g -> -- TODO: ignore the Label case
       genGram gbl g
-    PAST.NGuard e1 ->
+    TCGuard e1 ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [ (n1, UniChoice (SAct (Guard e1), n2)) ]) n2
-    PAST.NCurrnetStream ->
+    TCCurrentStream ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [ (n1, UniChoice (IAct (CurrentStream), n2)) ]) n2
-    PAST.NSetStream e1 ->
+    TCSetStream e1 ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [ (n1, UniChoice (IAct (SetStream e1), n2)) ]) n2
-    PAST.NStreamLen s e1 e2 ->
+    TCStreamLen s e1 e2 ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [ (n1, UniChoice (IAct (StreamLen s e1 e2), n2)) ]) n2
-    PAST.NStreamOff s e1 e2 ->
+    TCStreamOff s e1 e2 ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [ (n1, UniChoice (IAct (StreamOff s e1 e2), n2)) ]) n2
-    PAST.NGetByte s ->
+    TCGetByte s ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [ (n1, UniChoice (IAct (IGetByte s), n2)) ]) n2
-    PAST.NMatch s e1 ->
+    TCMatch s e1 ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [ (n1, UniChoice (IAct (ClssAct s e1), n2)) ]) n2
-    PAST.NMatchBytes s e1 ->
+    TCMatchBytes s e1 ->
       case getByteArray e1 of
         Nothing ->
           let n1 = st !! 0
@@ -300,9 +496,13 @@ genGExpr gbl (e, st) =
               then
                 case s of
                   YesSem -> [(stSemStart, UniChoice (SAct (EvalPure e1), stSemEnd))]
-                  NoSem  -> [(stSemStart, UniChoice (SAct (EvalPure PAST.NUnit), stSemEnd))]
+                  NoSem  ->
+                    let eunit = TC (TCAnnot { tcAnnot = texprAnnot e, tcAnnotExpr = TCUnit}) in
+                    [(stSemStart, UniChoice (SAct (EvalPure eunit), stSemEnd))]
               else
-                let iact = ClssAct NoSem (PAST.NSetSingle (PAST.NByte (w !! index)))
+                let ebyte = TC (TCAnnot { tcAnnot = texprAnnot e, tcAnnotExpr = TCByte (w !! index)})
+                    eSetSingle = TC (TCAnnot { tcAnnot = texprAnnot e, tcAnnotExpr = TCSetSingle ebyte})
+                    iact = ClssAct NoSem eSetSingle
                     n0 = st !! (2 * index)
                     n1 = st !! (2 * index + 1)
                     n2 = st !! (2 * (index + 1))
@@ -311,7 +511,7 @@ genGExpr gbl (e, st) =
                          ]
                 in tr ++ createTrans (index+1)
 
-    PAST.NChoice c lst _ty ->
+    TCChoice c lst _ty ->
       let lstITF = map (\ expr -> dsAut $ genGram gbl expr) lst
           n1 = st !! 0
           n2 = st !! 1
@@ -327,7 +527,7 @@ genGExpr gbl (e, st) =
                 transOut = foldr (\ (_i1,_t1,f1) accTr -> (f1, UniChoice (EpsA, n2)) : accTr) [] lstITF
                 transBdy = foldr (\ (_i1,t1,_f1) accTr -> unionTr t1 accTr) emptyTr lstITF
             in mkAut n1 (unionTr (mkTr1 (n1, ParChoice transIn)) (unionTr (mkTr transOut) transBdy)) n2
-    PAST.NOptional c e1 ->
+    TCOptional c e1 ->
       let (i1, t1, f1) = dsAut $ genGram gbl e1
           n1 = st !! 0
           n2 = st !! 1
@@ -342,7 +542,7 @@ genGExpr gbl (e, st) =
                   (f1, UniChoice (EpsA, n2))
                 ]
       in mkAut n1 (unionTr (mkTr trans) t1) n2
-    PAST.NMany s c bounds e1 ->
+    TCMany s c bounds e1 ->
       let (i1, t1, f1) = dsAut $ genGram gbl e1
           n1 = st !! 0
           n2 = st !! 1
@@ -372,73 +572,82 @@ genGExpr gbl (e, st) =
                   (n6, UniChoice (BAct (CutBiasAlt n7), n7))
                 ]
       in mkAut n1 (unionTr (mkTr loopTrans) t1) n7
-    PAST.NEnd ->
+    TCEnd ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [ (n1, UniChoice (IAct IEnd, n2)) ]) n2
-    PAST.NOffset ->
+    TCOffset ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [ (n1, UniChoice (IAct IOffset, n2)) ]) n2
-    PAST.NMapLookup ws e1 e2 ->
+    TCMapLookup ws e1 e2 ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [ (n1, UniChoice (SAct (MapLookup ws e1 e2), n2)) ]) n2
-    PAST.NMapInsert ws e1 e2 e3 ->
+    TCMapInsert ws e1 e2 e3 ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [ (n1, UniChoice (SAct (MapInsert ws e1 e2 e3), n2)) ]) n2
-    PAST.NCoerceCheck ws t1 t2 e1 ->
+    TCCoerceCheck ws t1 t2 e1 ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [ (n1, UniChoice (SAct (CoerceCheck ws t1 t2 e1), n2)) ]) n2
-    PAST.NSelUnion ws e1 lbl _ty ->
+    TCSelUnion ws e1 lbl _ty ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [(n1, UniChoice (SAct (SelUnion ws e1 lbl), n2))]) n2
-    PAST.NSelJust ws e1 _ty ->
+    TCSelJust ws e1 _ty ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [(n1, UniChoice (SAct (SelJust ws e1), n2))]) n2
-    PAST.NGFor nname1 e1 nname2 e2 gram ->
-      let n1 = st !! 0
-          n2 = st !! 1
-          n3 = st !! 2
-          (i1, t1, f1) = dsAut $ genGram gbl gram
-          trans = mkTr
-            [ (n1, UniChoice (CAct (ForInit nname1 e1 nname2 e2), n2))
-            , (n2, SeqChoice [ (CAct (ForHasMore), i1), (CAct (ForEnd), n3) ] n3)
-            , (f1, UniChoice (CAct (ForNext), n2))
-            ]
-      in mkAut n1 (unionTr trans t1) n3
-    PAST.NGMap nname1 e1 gram ->
-      let n1 = st !! 0
-          n2 = st !! 1
-          n3 = st !! 2
-          (i1, t1, f1) = dsAut $ genGram gbl gram
-          trans = mkTr
-            [ (n1, UniChoice (CAct (MapInit nname1 e1), n2))
-            , (n2, SeqChoice [ (CAct MapHasMore, i1), (CAct (MapEnd), n3) ] n3)
-            , (f1, UniChoice (CAct (MapNext), n2))
-            ]
-      in mkAut n1 (unionTr trans t1) n3
-    PAST.NGCall nname le ->
-      let name = PAST.nName nname
+    TCFor lp ->
+      case loopFlav lp of
+        Fold name1 e1 ->
+          let nname1 = tcName name1
+              nname2 = tcName (loopElName lp)
+              e2 = loopCol lp
+              gram = loopBody lp
+              n1 = st !! 0
+              n2 = st !! 1
+              n3 = st !! 2
+              (i1, t1, f1) = dsAut $ genGram gbl gram
+              trans = mkTr
+                [ (n1, UniChoice (CAct (ForInit nname1 e1 nname2 e2), n2))
+                , (n2, SeqChoice [ (CAct (ForHasMore), i1), (CAct (ForEnd), n3) ] n3)
+                , (f1, UniChoice (CAct (ForNext), n2))
+                ]
+          in mkAut n1 (unionTr trans t1) n3
+        LoopMap ->
+          let nname1 = tcName (loopElName lp)
+              e1 = loopCol lp
+              gram = loopBody lp
+              n1 = st !! 0
+              n2 = st !! 1
+              n3 = st !! 2
+              (i1, t1, f1) = dsAut $ genGram gbl gram
+              trans = mkTr
+                [ (n1, UniChoice (CAct (MapInit nname1 e1), n2))
+                , (n2, SeqChoice [ (CAct MapHasMore, i1), (CAct (MapEnd), n3) ] n3)
+                , (f1, UniChoice (CAct (MapNext), n2))
+                ]
+          in mkAut n1 (unionTr trans t1) n3
+    TCCall name _ le ->
+      let nname = tcName name
           (_, annot) =
-            let x = Map.lookup name gbl in
+            let x = Map.lookup nname gbl in
               case x of
-                Nothing -> error ("Name not found in gbl grammar: " ++ show name)
-                Just r -> r
+                Nothing -> error ("Name not found in gbl grammar: " ++ show nname)
+                Just r -> tcDeclAnnot r
           n1 = st !! 0
           n2 = st !! 1
           call = annot !! 0
           ret  = annot !! 1
           trans = mkTr
-            [ (n1, UniChoice (CAct (Push nname le n2), call))
+            [ (n1, UniChoice (CAct (Push nname (map argToValue le) n2), call))
             , (ret, UniChoice (CAct (Pop n2), n2))
             ]
       in mkAut n1 trans n2
-    PAST.NGErrorMode c e1 ->
+    TCErrorMode c e1 ->
       let n1 = st !! 0
           n2 = st !! 1
           (i1, t1, f1) = dsAut $ genGram gbl e1
@@ -450,75 +659,104 @@ genGExpr gbl (e, st) =
                 ]
               Backtrack -> error "not handled in ErrorMode"
       in mkAut n1 (unionTr (mkTr trans) t1) n2
-    PAST.NGFail e1 _ ->
+    TCFail e1 _ ->
       let n1 = st !! 0
           n2 = st !! 1
       in mkAut n1 (mkTr [(n1, UniChoice (BAct (FailAction e1), n2))]) n2
 
+    x -> error ("Case not handled: " ++ show x)
 
-genGram :: GblGrammar -> PAST.NGrammar -> MapAut
-genGram gbl (e, st) =
+data WhatGram = DoSeq | NonDoSeq
+
+{- To see how the states are allocated, see  `allocGram` function.
+   There are three cases
+   * 1) an expression is not Do/Pure then just call `genGExpr`
+   * 2) an expression has a Do/Pure
+     * a) if it ends with Pure then end with `ReturnBind`
+     * b) otherwise it ends with `ReturnLast`
+
+   TODO: 2 b) is where a tail call optimization could happen
+-}
+genGram :: PAST.GblGrammar -> TC (SourceRange, PAST.Annot) Grammar -> MapAut
+genGram gbl e =
   let
-    genForBindList :: PAST.NGrammar -> MapAut
-    genForBindList (expr, sts) =
-        case expr of
-          PAST.NBind mname e1 e2 ->
-            let (i1,t1,f1) = dsAut $ genGExpr gbl e1
-                (i2,t2,f2) = dsAut $ genForBindList e2
-                n1 = sts !! 0
-                n2 = sts !! 1
-                trans = mkTr
-                  [ (n1, UniChoice (EpsA, i1))
-                  , (f1, UniChoice (SAct (EnvStore mname), i2))
-                  , (f2, UniChoice (EpsA, n2))
-                  ]
-            in mkAut n1 (unionTr trans (unionTr t1 t2)) n2
-          PAST.NPure e1 ->
-            let n1 = sts !! 0
-                n2 = sts !! 1
-            in mkAut n1 (mkTr [(n1, UniChoice (SAct (ReturnBind e1), n2))]) n2
+    genForBindList :: TC (SourceRange, PAST.Annot) Grammar -> (MapAut, WhatGram)
+    genForBindList expr =
+      case texprValue expr of
+        TCDo _ _ _ -> (genForDo expr, DoSeq)
+        TCPure _   -> (genForDo expr, DoSeq)
+        _ -> (genGExpr gbl expr, NonDoSeq)
+
+    genForDo expr =
+      let sts = snd $ texprAnnot expr in
+      case texprValue expr of
+        TCDo mname e1 e2 ->
+          let name = maybe Nothing (\x -> Just $ tcName x) mname
+              (i1,t1,f1) = dsAut $ genGram gbl e1
+              (i2,t2,f2) = dsAut $ genForDo e2
+              n1 = sts !! 0
+              n2 = sts !! 1
+              trans = mkTr
+                [ (n1, UniChoice (EpsA, i1))
+                , (f1, UniChoice (SAct (EnvStore name), i2))
+                , (f2, UniChoice (EpsA, n2))
+                ]
+          in mkAut n1 (unionTr trans (unionTr t1 t2)) n2
+        TCPure e1 ->
+          let n1 = sts !! 0
+              n2 = sts !! 1
+          in mkAut n1 (mkTr [(n1, UniChoice (SAct (ReturnBind e1), n2))]) n2
+        _x ->
+          let
+              (i1,t1,f1) = dsAut $ genGExpr gbl expr
+              n1 = sts !! (length sts - 2)
+              n2 = sts !! (length sts - 1)
+              trans = mkTr
+                [ (n1, UniChoice (EpsA, i1))
+                , (f1, UniChoice (SAct ReturnLast, n2))
+                ]
+          in mkAut n1 (unionTr trans t1) n2
+
   in
-    let (i1,t1,f1) = dsAut $ genForBindList (e, st)
-        n1 = st !! 2
-        n2 = st !! 3
-        trans = mkTr [ (n1, UniChoice (SAct EnvFresh, i1)), (f1, UniChoice (EpsA, n2))]
+    let (aut, wg) = genForBindList e
+        (i1,t1,f1) = dsAut $ aut
+        st = snd $ texprAnnot e
+        n1 = st !! (length st - 2)
+        n2 = st !! (length st - 1)
+        trans =
+          case wg of
+            DoSeq -> mkTr [ (n1, UniChoice (SAct EnvFresh, i1)), (f1, UniChoice (EpsA, n2))]
+            NonDoSeq -> mkTr [ (n1, UniChoice (EpsA, i1)), (f1, UniChoice (EpsA, n2))]
     in mkAut n1 (unionTr trans t1) n2
 
 
-genDeclBody :: GblGrammar -> PAST.NDeclBody -> MapAut
-genDeclBody gbl (e, st) =
-  case e of
-    PAST.NCDecl _e1 ->
-      let n1 = st !! 0
-          n2 = st !! 1
-      in mkAut n1 emptyTr n2
-    PAST.NVDecl _e1 ->
-      let n1 = st !! 0
-          n2 = st !! 1
-      in mkAut n1 emptyTr n2
-    PAST.NGDecl e1 ->
-      let (i1,t1,f1) = dsAut $ genGram gbl e1
-          n1 = st !! 0
-          n2 = st !! 1
-          trans = mkTr [ (n1, UniChoice (EpsA, i1)), (f1, UniChoice (EpsA, n2)) ]
-      in mkAut n1 (unionTr trans t1) n2
-    PAST.NExtern ->
-      let n1 = st !! 0
-          n2 = st !! 1
-      in mkAut n1 (mkTr [(n1, UniChoice (EpsA, n2))]) n2
-
-genDecl :: GblGrammar -> PAST.NDecl -> MapAut
-genDecl gbl (e, st) =
-  let (i1,t1,f1) = dsAut $ genDeclBody gbl (PAST.nDeclDef e)
+genDecl :: PAST.GblGrammar -> TCDecl (SourceRange, PAST.Annot) -> MapAut
+genDecl gbl (TCDecl {tcDeclCtxt = AGrammar, tcDeclDef = Defined e, tcDeclAnnot = (_,st), tcDeclParams = ps}) =
+  let (i1,t1,f1) = dsAut $ genGram gbl e
       n1 = st !! 0
       n2 = st !! 1
       trans = mkTr
-        [ (n1, UniChoice (CAct (ActivateFrame (PAST.nDeclParams e)), i1))
+        [ (n1, UniChoice (CAct (ActivateFrame (map paramToName ps)), i1))
         , (f1, UniChoice (CAct (DeactivateReady), n2))
         ]
   in mkAut n1 (unionTr trans t1) n2
+genDecl _gbl _ = error "broken invariant"
 
-buildMapAut :: [NDecl] -> (PAST.GblFuns, MapAut)
+
+getTCModuleAnnot :: TCModule (a, PAST.Annot) -> PAST.Annot
+getTCModuleAnnot (TCModule {tcModuleDecls = [ NonRec (TCDecl {tcDeclAnnot = annot})]}) = snd annot
+getTCModuleAnnot _ = error "broken invariant"
+
+getTCModuleName :: TCModule (a, PAST.Annot) -> Name
+getTCModuleName (TCModule {tcModuleDecls = [ NonRec (TCDecl {tcDeclCtxt = AGrammar, tcDeclDef = Defined _, tcDeclName = name})]}) = name
+getTCModuleName _ = error "broken invariant"
+
+
+getTCModuleDecl :: TCModule (a, PAST.Annot) -> TCDecl (a, PAST.Annot)
+getTCModuleDecl (TCModule {tcModuleDecls = [ NonRec decl@(TCDecl {tcDeclCtxt = AGrammar, tcDeclDef = Defined _})]}) = decl
+getTCModuleDecl _ = error "broken invariant"
+
+buildMapAut :: [TCModule SourceRange] -> (PAST.GblFuns, MapAut)
 buildMapAut decls =
   (systemToFunctions allocDecls,
    mkAut globalStartState (unionTr trans table) globalFinalState
@@ -526,7 +764,7 @@ buildMapAut decls =
   where
     allocDecls = allocStates decls
     allocGrammar = systemToGrammars allocDecls
-    (_, mainInfo) = fromJust $ Map.foldrWithKey
+    (mainFullName, mainInfo) = fromJust $ Map.foldrWithKey
       (\ k a b ->
          case b of
            Just res -> Just res
@@ -535,19 +773,19 @@ buildMapAut decls =
                -- TODO: this infixOf test should be removed
                if isInfixOf "Main" (show ident) then Just (k, a) else Nothing
       ) Nothing allocDecls
-    mainAnnots = snd mainInfo
+    mainAnnots = getTCModuleAnnot mainInfo
     startState = mainAnnots !! 0
     finalState = mainAnnots !! 1
-    mainName = PAST.NName {PAST.nName = PAST.nDeclName $ fst mainInfo}
+    mainName = mainFullName
     f a tr =
       let (_i, t, _f) = dsAut $ genDecl allocGrammar a in unionTr t tr
-    table = foldr f emptyTr allocDecls
+    table = foldr f emptyTr (Map.foldr (\ decl acc -> decl : acc) [] allocGrammar)
     trans = mkTr
       [ (globalStartState, UniChoice (CAct (Push mainName [] globalFinalState), startState))
       , (finalState,       UniChoice (CAct (Pop globalFinalState), globalFinalState))
       ]
 
-buildArrayAut :: [NDecl] -> (PAST.GblFuns, ArrayAut)
+buildArrayAut :: [TCModule SourceRange] -> (PAST.GblFuns, ArrayAut)
 buildArrayAut decls =
   let
     (fns, aut) = buildMapAut decls

--- a/src/Daedalus/ParserGen/Det.hs
+++ b/src/Daedalus/ParserGen/Det.hs
@@ -1,3 +1,5 @@
+{-# Language GADTs #-}
+
 module Daedalus.ParserGen.Det
   ( createDFA
   , statsDFA
@@ -20,6 +22,7 @@ import Data.Maybe (fromJust)
 import qualified RTS.Input as Input
 import qualified Daedalus.Interp as Interp
 
+import Daedalus.Type.AST
 import Daedalus.ParserGen.AST as PAST
 import Daedalus.ParserGen.Action (State, Action(..), InputAction(..), isClassActOrEnd, isInputAction, isNonClassInputAct, getClassActOrEnd, evalNoFunCall, isSimpleVExpr)
 import Daedalus.ParserGen.Aut (Aut(..), Choice(..))
@@ -125,9 +128,9 @@ closureLL aut busy cfg =
 
 classToInterval :: PAST.NCExpr -> Result ClassInterval
 classToInterval e =
-  case e of
-    PAST.NSetAny -> Result $ ClassBtw MinusInfinity PlusInfinity
-    PAST.NSetSingle e1 ->
+  case texprValue e of
+    TCSetAny -> Result $ ClassBtw MinusInfinity PlusInfinity
+    TCSetSingle e1 ->
       if not (isSimpleVExpr e1)
       then AbortClassIsDynamic
       else
@@ -135,7 +138,7 @@ classToInterval e =
         case v of
           Interp.VUInt 8 x -> Result $ ClassBtw (CValue (fromIntegral x)) (CValue (fromIntegral x))
           _                -> AbortClassNotHandledYet "SetSingle"
-    PAST.NSetRange e1 e2 ->
+    TCSetRange e1 e2 ->
       if isSimpleVExpr e1 && isSimpleVExpr e2
       then
         let v1 = evalNoFunCall e1 [] []

--- a/src/Daedalus/ParserGen/RunnerBias.hs
+++ b/src/Daedalus/ParserGen/RunnerBias.hs
@@ -142,7 +142,6 @@ nextResumption (commitStk, tpath) =
 
     BLevel _ path _ (SeqChoice [ _ ] _) -> nextResumption (popCommitStack commitStk, path)
     BLevel _ path cfg (SeqChoice ((_act, _n2): actions) st) ->
-            -- trace "BACKT" $
       if hasCommitted commitStk -- A commit happened
       then nextResumption (popCommitStack commitStk, path)
       else Just (addResumption (popCommitStack commitStk, path) cfg (SeqChoice actions st))
@@ -176,7 +175,6 @@ updateError resumption cfg res =
   case parseError res of
     Nothing -> res { parseError = Just (i, cfg) }
     Just (j, _c) ->
-      -- trace "CHANGE" $
       if i >= j
       then res { parseError = Just (i, cfg) }
       else res

--- a/src/Daedalus/ParserGen/Utils.hs
+++ b/src/Daedalus/ParserGen/Utils.hs
@@ -28,7 +28,7 @@ autToGraphviz aut =
                             _     -> "S" ++ show n2
               startNode = "S" ++ show n1
               strAct = case act of
-                         CAct (Push name _ _) -> "Push_" ++ tail (removeLast (show name)) ++ "_S" ++ show n2
+                         CAct (Push name _ _) -> "Push_" ++ tail (removeLast (showName name)) ++ "_S" ++ show n2
                          CAct (Pop n) -> "Pop" ++ show n
                          _     -> show act
               isDotted = case act of

--- a/src/Daedalus/Specialise/PartialApply.hs
+++ b/src/Daedalus/Specialise/PartialApply.hs
@@ -45,7 +45,8 @@ partialApply tnm' targs newPs args
   TCDecl { tcDeclTyParams = ttys,
            tcDeclParams   = tparams,
            tcDeclDef      = tdef,
-           tcDeclCtxt     =  tctxt
+           tcDeclCtxt     =  tctxt,
+           tcDeclAnnot    = tannot
          }
   =
   TCDecl {
@@ -54,7 +55,8 @@ partialApply tnm' targs newPs args
     tcDeclCtrs     = [],
     tcDeclParams   = tparams' ++ newPs',
     tcDeclDef      = tdef',
-    tcDeclCtxt     = tctxt
+    tcDeclCtxt     = tctxt,
+    tcDeclAnnot    = tannot
   }
 
   where

--- a/src/Daedalus/Type.hs
+++ b/src/Daedalus/Type.hs
@@ -254,6 +254,7 @@ doGeneralize as cs tparams decls
                         Defined d | r -> Defined (fixUpRecCallSites dMap d)
                         res ->  res
                   , tcDeclCtxt     = tcDeclCtxt
+                  , tcDeclAnnot    = tcDeclAnnot
                   }
 
   addTPsTy d = fixUpTCons tconMap d { tctyParams = tparams Map.! tctyName d }
@@ -411,6 +412,7 @@ inferRule r = runTypeM (ruleName r) (addParams [] (ruleParams r))
                                 , tcDeclParams   = tps
                                 , tcDeclDef      = def
                                 , tcDeclCtxt     = nameContext
+                                , tcDeclAnnot    = ruleRange r
                                 }
                pure (d, map typeOf tps :-> typeOf def)
 
@@ -1489,9 +1491,3 @@ pureStruct r ls ts es
                pure (exprAt r (TCStruct (zip ls es) ty), ty)
   where
   repeated = [ l | (l : _ : _) <- group (sort ls) ]
-
-
-
-
-
-

--- a/src/Daedalus/Type/AST.hs
+++ b/src/Daedalus/Type/AST.hs
@@ -249,6 +249,7 @@ data TCDecl a   = forall k.
                          , tcDeclParams   :: ![Param]
                          , tcDeclDef      :: !(TCDeclDef a k)
                          , tcDeclCtxt     :: !(Context k)
+                         , tcDeclAnnot    :: !(a)
                          }
 
 deriving instance Show a => Show (TCDecl a)
@@ -378,10 +379,10 @@ instance PP (TCF a k) where
       TCMapLookup s k m ->
           wrapIf (n > 0) (annotKW' s "Lookup" <+> ppPrec 1 k <+> ppPrec 1 m)
 
-      TCArrayLength e -> 
+      TCArrayLength e ->
           wrapIf (n > 0) ("Length" <+> ppPrec 1 e)
 
-      TCArrayIndex s v ix -> 
+      TCArrayIndex s v ix ->
           wrapIf (n > 0) (annotKW' s "Index" <+> ppPrec 1 v <+> ppPrec 1 ix)
 
       TCChoice c es _ -> "Choose" <+> pp c $$
@@ -538,7 +539,7 @@ ppTyDef sc =
 
 -- This is a hack, it assumes that Commit doesn't add anything
 annotKW' :: WithSem -> Doc -> Doc
-annotKW' s = annotKW s Commit 
+annotKW' s = annotKW s Commit
 
 annotKW :: WithSem -> Commit -> Doc -> Doc
 annotKW s cmt kw = pref <.> kw <.> suff
@@ -875,7 +876,7 @@ instance Eq (TCName k) where
 
 instance EqF TCName where
   eqF k k' = k == k'
-  
+
 -- NOTE: these ignore types, so names with different types will cause issues.
 instance OrdF TCName where
   compareF tn1 tn2 =

--- a/src/Daedalus/Type/AST.hs
+++ b/src/Daedalus/Type/AST.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TemplateHaskell #-} -- For deriving ord and eqs
 {-# Language StandaloneDeriving #-}
 module Daedalus.Type.AST
-  ( module Daedalus.Type.AST 
+  ( module Daedalus.Type.AST
   , module LocalAST
   , Rec(..), recToList
   , SourceRange

--- a/src/Daedalus/Type/DeadVal.hs
+++ b/src/Daedalus/Type/DeadVal.hs
@@ -150,7 +150,7 @@ declareMatchFun ::
   Map Name ArgInfo -> TCDecl SourceRange -> Maybe (TCDecl SourceRange, ArgInfo)
 declareMatchFun mfs dcl =
   case dcl of
-    TCDecl { tcDeclCtxt = AGrammar, tcDeclDef } ->
+    TCDecl { tcDeclCtxt = AGrammar, tcDeclDef, tcDeclAnnot } ->
       let newName = TCName { tcNameCtx = AGrammar
                            , tcType    = tGrammar tUnit
                            , tcName    = modifyName (tcDeclName dcl)
@@ -170,6 +170,7 @@ declareMatchFun mfs dcl =
                       , tcDeclParams   = tcDeclParams dcl
                       , tcDeclDef      = Defined newDef
                       , tcDeclCtxt     = AGrammar
+                      , tcDeclAnnot    = tcDeclAnnot
                       }
            newInfo = ArgInfo { matchFun = newName
                              , passArg  = map (const True) (tcDeclParams dcl)
@@ -211,6 +212,7 @@ declareMatchFun mfs dcl =
                           , tcDeclParams   = newParams
                           , tcDeclDef      = Defined def
                           , tcDeclCtxt     = AGrammar
+                          , tcDeclAnnot    = tcDeclAnnot
                           }
 
               newParams = [ p | p <- tcDeclParams dcl, pused p ] ++
@@ -278,7 +280,7 @@ mbSem tc =
     TCMapLookup {}    -> pure (tc, tcFree tc)
     TCMapInsert {}    -> pure (tc, tcFree tc)
     TCArrayIndex  {}  -> pure (tc, tcFree tc)
-    
+
     TCCoerceCheck {}  -> pure (tc, tcFree tc)
     TCSelUnion {}     -> pure (tc, tcFree tc)
     TCSelJust {}      -> pure (tc, tcFree tc)
@@ -380,7 +382,7 @@ noSem' tc =
       pure ( exprAt tc (TCMapInsert NoSem k v mp)
            , tcFree k <> tcFree v <> tcFree mp )
 
-     TCArrayIndex _ e ix -> 
+     TCArrayIndex _ e ix ->
       pure (exprAt tc (TCArrayIndex NoSem e ix), tcFree e <> tcFree ix)
 
      TCCoerceCheck _ t1 t2 v ->
@@ -497,6 +499,3 @@ mkDo r x m1 m2
     = m2
 
   | otherwise = exprAt r (TCDo x m1 m2)
-
-
- 

--- a/tests/parser-gen/D001.test.stdout
+++ b/tests/parser-gen/D001.test.stdout
@@ -9,13 +9,13 @@ DTrans [
   ),
 ]
 DTrans [
-  ( [(15),]
+  ( [(11),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(15),]
+  ( [(11),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),

--- a/tests/parser-gen/D002.test.stdout
+++ b/tests/parser-gen/D002.test.stdout
@@ -1,5 +1,5 @@
 DTrans [
-  ( [(10),(10),]
+  ( [(8),(8),]
   , HeadInput ['a']
   , DTrans [
       ( [(1),]
@@ -20,13 +20,13 @@ DTrans [
   ),
 ]
 DTrans [
-  ( [(18),(18),]
+  ( [(12),(12),]
   , HeadInput ['a']
   , DTrans [
       ( [(1),(1),]
       , HeadInput ['b']
       , DTrans [
-          ( [(13),(13),]
+          ( [(9),(9),]
           , EndInput
           , Resolution (Ambiguous)
           ),
@@ -42,13 +42,13 @@ DTrans [
   ),
 ]
 DTrans [
-  ( [(18),(18),]
+  ( [(12),(12),]
   , HeadInput ['a']
   , DTrans [
       ( [(1),(1),]
       , HeadInput ['b']
       , DTrans [
-          ( [(13),(13),]
+          ( [(9),(9),]
           , EndInput
           , Resolution (Ambiguous)
           ),
@@ -64,7 +64,7 @@ DTrans [
   ),
 ]
 DTrans [
-  ( [(13),]
+  ( [(9),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),
@@ -76,7 +76,7 @@ DTrans [
   ),
 ]
 DTrans [
-  ( [(13),]
+  ( [(9),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),

--- a/tests/parser-gen/D003.test.stdout
+++ b/tests/parser-gen/D003.test.stdout
@@ -1,46 +1,46 @@
 DTrans [
-  ( [(10),]
+  ( [(12),]
   , HeadInput ['0','2']
   , Resolution (NotAmbiguous)
   ),
-  ( [(10),(10),]
+  ( [(12),(12),]
   , HeadInput ['3','7']
   , DTrans [
-      ( [(2),]
+      ( [(4),]
       , HeadInput ['a']
       , Resolution (NotAmbiguous)
       ),
-      ( [(2),]
+      ( [(4),]
       , HeadInput ['b']
       , Resolution (NotAmbiguous)
       ),
     ]
   ),
-  ( [(10),]
+  ( [(12),]
   , HeadInput ['8','9']
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(2),]
+  ( [(4),]
   , HeadInput ['b']
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(20),]
+  ( [(16),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(2),]
+  ( [(4),]
   , HeadInput ['a']
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(20),]
+  ( [(16),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),

--- a/tests/parser-gen/D004.test.stdout
+++ b/tests/parser-gen/D004.test.stdout
@@ -1,55 +1,55 @@
 DTrans [
-  ( [(10),]
+  ( [(12),]
   , HeadInput ['0','2']
   , Resolution (NotAmbiguous)
   ),
-  ( [(10),(10),]
+  ( [(12),(12),]
   , HeadInput ['3','7']
   , DTrans [
-      ( [(2),]
+      ( [(4),]
       , HeadInput ['a','w']
       , Resolution (NotAmbiguous)
       ),
-      ( [(2),(2),]
+      ( [(4),(4),]
       , HeadInput ['x','y']
       , DTrans [
-          ( [(20),(20),]
+          ( [(16),(16),]
           , EndInput
           , Resolution (Ambiguous)
           ),
         ]
       ),
-      ( [(2),]
+      ( [(4),]
       , HeadInput ['z']
       , Resolution (NotAmbiguous)
       ),
     ]
   ),
-  ( [(10),]
+  ( [(12),]
   , HeadInput ['8','9']
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(2),]
+  ( [(4),]
   , HeadInput ['x','z']
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(20),]
+  ( [(16),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(2),]
+  ( [(4),]
   , HeadInput ['a','y']
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(20),]
+  ( [(16),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),

--- a/tests/parser-gen/D005.test.stdout
+++ b/tests/parser-gen/D005.test.stdout
@@ -1,18 +1,18 @@
 DTrans [
-  ( [(10),(15),]
+  ( [(15),(10),]
   , HeadInput ['a']
   , DTrans [
-      ( [(7),(2),]
+      ( [(3),(9),]
       , HeadInput ['b']
       , DTrans [
-          ( [(10),(2),]
+          ( [(3),(8),]
           , HeadInput ['c']
           , DTrans [
-              ( [(10),]
+              ( [(8),]
               , HeadInput ['d']
               , Resolution (NotAmbiguous)
               ),
-              ( [(12),]
+              ( [(9),]
               , EndInput
               , Resolution (NotAmbiguous)
               ),
@@ -24,49 +24,49 @@ DTrans [
   ),
 ]
 DTrans [
-  ( [(7),]
+  ( [(3),]
   , HeadInput ['b']
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(13),]
+  ( [(8),]
+  , HeadInput ['c']
+  , Resolution (NotAmbiguous)
+  ),
+]
+DTrans [
+  ( [(3),]
+  , HeadInput ['c']
+  , Resolution (NotAmbiguous)
+  ),
+]
+DTrans [
+  ( [(8),]
+  , HeadInput ['d']
+  , Resolution (NotAmbiguous)
+  ),
+]
+DTrans [
+  ( [(9),]
+  , HeadInput ['b']
+  , Resolution (NotAmbiguous)
+  ),
+]
+DTrans [
+  ( [(10),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(12),]
+  ( [(9),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),
 ]
 AbortAcceptingPath
 
-DTrans [
-  ( [(2),]
-  , HeadInput ['c']
-  , Resolution (NotAmbiguous)
-  ),
-]
-DTrans [
-  ( [(10),]
-  , HeadInput ['d']
-  , Resolution (NotAmbiguous)
-  ),
-]
-DTrans [
-  ( [(2),]
-  , HeadInput ['b']
-  , Resolution (NotAmbiguous)
-  ),
-]
-DTrans [
-  ( [(10),]
-  , HeadInput ['c']
-  , Resolution (NotAmbiguous)
-  ),
-]
 
 Report:
 ("AbortAcceptingPath",1)

--- a/tests/parser-gen/D006.test.stdout
+++ b/tests/parser-gen/D006.test.stdout
@@ -1,58 +1,58 @@
 DTrans [
-  ( [(20),(20),]
+  ( [(17),(17),]
   , HeadInput ['a']
   , DTrans [
-      ( [(12),(12),]
+      ( [(8),(8),]
       , HeadInput ['a']
       , *****
       ),
-      ( [(20),]
+      ( [(14),]
       , HeadInput ['c']
       , Resolution (NotAmbiguous)
       ),
-      ( [(20),]
+      ( [(14),]
       , HeadInput ['d']
       , Resolution (NotAmbiguous)
       ),
     ]
   ),
-  ( [(28),]
+  ( [(23),]
   , HeadInput ['c']
   , Resolution (NotAmbiguous)
   ),
-  ( [(28),]
+  ( [(23),]
   , HeadInput ['d']
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
+  ( [(8),]
+  , HeadInput ['a']
+  , Resolution (NotAmbiguous)
+  ),
   ( [(14),]
+  , HeadInput ['c']
+  , Resolution (NotAmbiguous)
+  ),
+  ( [(14),]
+  , HeadInput ['d']
+  , Resolution (NotAmbiguous)
+  ),
+]
+DTrans [
+  ( [(11),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(14),]
+  ( [(11),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),
 ]
 AbortAcceptingPath
 
-DTrans [
-  ( [(12),]
-  , HeadInput ['a']
-  , Resolution (NotAmbiguous)
-  ),
-  ( [(20),]
-  , HeadInput ['c']
-  , Resolution (NotAmbiguous)
-  ),
-  ( [(20),]
-  , HeadInput ['d']
-  , Resolution (NotAmbiguous)
-  ),
-]
 
 Report:
 ("AbortAcceptingPath",1)

--- a/tests/parser-gen/D007.test.stdout
+++ b/tests/parser-gen/D007.test.stdout
@@ -1,211 +1,211 @@
 DTrans [
-  ( [(20),]
+  ( [(17),]
   , HeadInput ['a','b']
   , Resolution (NotAmbiguous)
   ),
-  ( [(28),(20),]
+  ( [(17),(23),]
   , HeadInput ['c']
   , DTrans [
-      ( [(10),]
+      ( [(6),]
       , HeadInput ['a','b']
       , Resolution (NotAmbiguous)
       ),
-      ( [(18),(10),]
+      ( [(6),(12),]
       , HeadInput ['c']
       , *****
       ),
-      ( [(10),]
+      ( [(6),]
       , HeadInput ['d','m']
       , Resolution (NotAmbiguous)
       ),
-      ( [(14),]
+      ( [(11),]
       , EndInput
       , Resolution (NotAmbiguous)
       ),
     ]
   ),
-  ( [(28),(20),]
+  ( [(17),(23),]
   , HeadInput ['d']
   , DTrans [
-      ( [(10),]
+      ( [(6),]
       , HeadInput ['a','b']
       , Resolution (NotAmbiguous)
       ),
-      ( [(18),(10),]
+      ( [(6),(12),]
       , HeadInput ['c']
       , DTrans [
-          ( [(10),]
+          ( [(6),]
           , HeadInput ['a','b']
           , Resolution (NotAmbiguous)
           ),
-          ( [(18),(10),]
+          ( [(6),(12),]
           , HeadInput ['c']
           , *****
           ),
-          ( [(10),]
+          ( [(6),]
           , HeadInput ['d','m']
           , Resolution (NotAmbiguous)
           ),
-          ( [(14),]
+          ( [(11),]
           , EndInput
           , Resolution (NotAmbiguous)
           ),
         ]
       ),
-      ( [(10),]
+      ( [(6),]
       , HeadInput ['d','m']
       , Resolution (NotAmbiguous)
       ),
-      ( [(14),]
+      ( [(11),]
       , EndInput
       , Resolution (NotAmbiguous)
       ),
     ]
   ),
-  ( [(20),]
+  ( [(17),]
   , HeadInput ['e']
   , Resolution (NotAmbiguous)
   ),
-  ( [(20),(20),]
+  ( [(17),(17),]
   , HeadInput ['f','m']
   , DTrans [
-      ( [(10),]
+      ( [(6),]
       , HeadInput ['a','b']
       , Resolution (NotAmbiguous)
       ),
-      ( [(18),(10),]
+      ( [(6),(12),]
       , HeadInput ['c']
       , DTrans [
-          ( [(10),]
+          ( [(6),]
           , HeadInput ['a','b']
           , Resolution (NotAmbiguous)
           ),
-          ( [(18),(10),]
+          ( [(6),(12),]
           , HeadInput ['c']
           , *****
           ),
-          ( [(10),]
+          ( [(6),]
           , HeadInput ['d','m']
           , Resolution (NotAmbiguous)
           ),
-          ( [(14),]
+          ( [(11),]
           , EndInput
           , Resolution (NotAmbiguous)
           ),
         ]
       ),
-      ( [(18),(10),]
+      ( [(6),(12),]
       , HeadInput ['d']
       , DTrans [
-          ( [(10),]
+          ( [(6),]
           , HeadInput ['a','b']
           , Resolution (NotAmbiguous)
           ),
-          ( [(18),(10),]
+          ( [(6),(12),]
           , HeadInput ['c']
           , DTrans [
-              ( [(10),]
+              ( [(6),]
               , HeadInput ['a','b']
               , Resolution (NotAmbiguous)
               ),
-              ( [(18),(10),]
+              ( [(6),(12),]
               , HeadInput ['c']
               , *****
               ),
-              ( [(10),]
+              ( [(6),]
               , HeadInput ['d','m']
               , Resolution (NotAmbiguous)
               ),
-              ( [(14),]
+              ( [(11),]
               , EndInput
               , Resolution (NotAmbiguous)
               ),
             ]
           ),
-          ( [(10),]
+          ( [(6),]
           , HeadInput ['d','m']
           , Resolution (NotAmbiguous)
           ),
-          ( [(14),]
+          ( [(11),]
           , EndInput
           , Resolution (NotAmbiguous)
           ),
         ]
       ),
-      ( [(10),]
+      ( [(6),]
       , HeadInput ['e']
       , Resolution (NotAmbiguous)
       ),
-      ( [(10),(10),]
+      ( [(6),(6),]
       , HeadInput ['f','m']
       , *****
       ),
-      ( [(10),]
+      ( [(6),]
       , HeadInput ['n','t']
       , Resolution (NotAmbiguous)
       ),
     ]
   ),
-  ( [(20),]
+  ( [(17),]
   , HeadInput ['n','t']
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(14),]
+  ( [(6),]
+  , HeadInput ['a','b']
+  , Resolution (NotAmbiguous)
+  ),
+  ( [(6),(12),]
+  , HeadInput ['c']
+  , DTrans [
+      ( [(6),]
+      , HeadInput ['a','b']
+      , Resolution (NotAmbiguous)
+      ),
+      ( [(6),(12),]
+      , HeadInput ['c']
+      , *****
+      ),
+      ( [(6),]
+      , HeadInput ['d','m']
+      , Resolution (NotAmbiguous)
+      ),
+      ( [(11),]
+      , EndInput
+      , Resolution (NotAmbiguous)
+      ),
+    ]
+  ),
+  ( [(6),]
+  , HeadInput ['d','m']
+  , Resolution (NotAmbiguous)
+  ),
+]
+DTrans [
+  ( [(12),]
+  , HeadInput ['d']
+  , Resolution (NotAmbiguous)
+  ),
+  ( [(6),]
+  , HeadInput ['f','t']
+  , Resolution (NotAmbiguous)
+  ),
+]
+DTrans [
+  ( [(11),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),
 ]
 DTrans [
-  ( [(14),]
+  ( [(11),]
   , EndInput
   , Resolution (NotAmbiguous)
   ),
 ]
 AbortAcceptingPath
 
-DTrans [
-  ( [(18),]
-  , HeadInput ['d']
-  , Resolution (NotAmbiguous)
-  ),
-  ( [(10),]
-  , HeadInput ['f','t']
-  , Resolution (NotAmbiguous)
-  ),
-]
-DTrans [
-  ( [(10),]
-  , HeadInput ['a','b']
-  , Resolution (NotAmbiguous)
-  ),
-  ( [(18),(10),]
-  , HeadInput ['c']
-  , DTrans [
-      ( [(10),]
-      , HeadInput ['a','b']
-      , Resolution (NotAmbiguous)
-      ),
-      ( [(18),(10),]
-      , HeadInput ['c']
-      , *****
-      ),
-      ( [(10),]
-      , HeadInput ['d','m']
-      , Resolution (NotAmbiguous)
-      ),
-      ( [(14),]
-      , EndInput
-      , Resolution (NotAmbiguous)
-      ),
-    ]
-  ),
-  ( [(10),]
-  , HeadInput ['d','m']
-  , Resolution (NotAmbiguous)
-  ),
-]
 
 Report:
 ("AbortAcceptingPath",1)


### PR DESCRIPTION
This PR makes `ParserGen` use the specialized syntax and its `TC` type for the AST of DaeDaLus grammars.
The unit tests and nitf tests are passing.

Main changes:
* Add an annotation field to `TCDecl` following how it is done in `TC`
* Changes in compilation pass producing the NFA since it cannot rely on do-sequences being normalized
* Handle more details related to Module structure that were hidden in the normalized syntax.
