### PR TITLE
Hashcons LL(*) states

### DIFF
--- a/daedalus.cabal
+++ b/daedalus.cabal
@@ -66,7 +66,7 @@ library
                        Daedalus.ParserGen.LL.Result,
                        Daedalus.ParserGen.LL.SlkCfg,
                        Daedalus.ParserGen.LL.Closure,
-                       Daedalus.ParserGen.LL.DeterminizeOneStep,
+                       Daedalus.ParserGen.LL.DFAStep,
                        Daedalus.ParserGen.LL.DFA,
                        Daedalus.ParserGen.LL.LLA,
                        Daedalus.ParserGen.RunnerBias,

--- a/src/Daedalus/ParserGen/Action.hs
+++ b/src/Daedalus/ParserGen/Action.hs
@@ -190,8 +190,8 @@ isActivateFrameAction act =
     CAct (ActivateFrame {}) -> True
     _ -> False
 
-isNonClassInputAct :: Action -> Bool
-isNonClassInputAct act =
+isUnhandledInputAction :: Action -> Bool
+isUnhandledInputAction act =
   case act of
     IAct iact ->
       case iact of

--- a/src/Daedalus/ParserGen/LL/DFA.hs
+++ b/src/Daedalus/ParserGen/LL/DFA.hs
@@ -268,14 +268,7 @@ maxDepthDet = 20
 
 getConflictSetsPerLoc :: DFARegistry -> [ [DFAEntry] ]
 getConflictSetsPerLoc s =
-  case iterDFARegistry s of
-    Nothing -> []
-    Just (e, es) ->
-      case findAllEntryInDFARegistry es (sameEntryPerLoc e) of
-        (lst, rs) ->
-          let lstLst = getConflictSetsPerLoc rs
-          in  (e : lst) : lstLst
-
+  partitionDFARegistry s sameEntryPerLoc
   where
     sameEntryPerLoc
       (DFAEntry _src1 (Closure.ClosurePath _alts1 _ (_,_,_) dst1))

--- a/src/Daedalus/ParserGen/LL/DFA.hs
+++ b/src/Daedalus/ParserGen/LL/DFA.hs
@@ -28,7 +28,7 @@ import Daedalus.ParserGen.Aut (Aut(..))
 import Daedalus.ParserGen.LL.Result
 import Daedalus.ParserGen.LL.SlkCfg
 import qualified Daedalus.ParserGen.LL.Closure as Closure
-import Daedalus.ParserGen.LL.DeterminizeOneStep
+import Daedalus.ParserGen.LL.DFAStep
 
 
 

--- a/src/Daedalus/ParserGen/LL/DFAStep.hs
+++ b/src/Daedalus/ParserGen/LL/DFAStep.hs
@@ -274,7 +274,7 @@ determinizeMove src tc =
               Result newAcc -> determinizeWithAccu ms (Just $ inp) newAcc
               _ -> error "impossible abort"
           else
-            Abort AbortIncompatibleInput
+            Abort AbortDFAIncompatibleInput
 
     compatibleInput :: SCfg.SlkInput -> Maybe SCfg.SlkInput -> Bool
     compatibleInput inp minp =
@@ -290,11 +290,11 @@ deterministicSlkCfg :: Aut a => a -> SCfg.SlkCfg -> Result DetChoice
 deterministicSlkCfg aut cfg =
   let res = Closure.closureLL aut cfg in
   case res of
-    Abort AbortOverflowMaxDepth -> coerceAbort res
-    Abort AbortLoopWithNonClass -> coerceAbort res
-    Abort (AbortNonClassInputAction _) -> coerceAbort res
-    Abort AbortUnhandledAction -> coerceAbort res
-    Abort AbortSymbolicExec -> coerceAbort res
+    Abort AbortSlkCfgExecution -> coerceAbort res
+    Abort AbortClosureOverflowMaxDepth -> coerceAbort res
+    Abort AbortClosureInfiniteloop -> coerceAbort res
+    Abort AbortClosureUnhandledInputAction -> coerceAbort res
+    Abort AbortClosureUnhandledAction -> coerceAbort res
     Result r -> determinizeMove cfg r
     _ -> error "Impossible abort"
 
@@ -436,14 +436,14 @@ determinizeDFAState aut s =
         Just (cfg, rest) ->
           let r = deterministicSlkCfg aut cfg in
           case r of
-            Abort AbortOverflowMaxDepth -> coerceAbort r
-            Abort AbortLoopWithNonClass -> coerceAbort r
-            Abort (AbortNonClassInputAction _) -> coerceAbort r
-            Abort AbortUnhandledAction -> coerceAbort r
+            Abort AbortSlkCfgExecution -> coerceAbort r
+            Abort AbortClosureOverflowMaxDepth -> coerceAbort r
+            Abort AbortClosureInfiniteloop -> coerceAbort r
+            Abort AbortClosureUnhandledInputAction -> coerceAbort r
+            Abort AbortClosureUnhandledAction -> coerceAbort r
             Abort AbortClassIsDynamic -> coerceAbort r
-            Abort AbortIncompatibleInput -> coerceAbort r
+            Abort AbortDFAIncompatibleInput -> coerceAbort r
             Abort (AbortClassNotHandledYet _) -> coerceAbort r
-            Abort AbortSymbolicExec -> coerceAbort r
             Result r1 ->
               let newAcc = unionDetChoice r1 acc
               in determinizeAcc rest newAcc

--- a/src/Daedalus/ParserGen/LL/DFAStep.hs
+++ b/src/Daedalus/ParserGen/LL/DFAStep.hs
@@ -1,6 +1,6 @@
 {-# Language GADTs #-}
 
-module Daedalus.ParserGen.LL.DeterminizeOneStep
+module Daedalus.ParserGen.LL.DFAStep
   ( SourceCfg,
     DFAEntry(..),
     DFARegistry,

--- a/src/Daedalus/ParserGen/LL/DFAStep.hs
+++ b/src/Daedalus/ParserGen/LL/DFAStep.hs
@@ -368,6 +368,8 @@ isEmptyIteratorDFAState (Iterator { iii = _r, curr = c, size = s}) =
   then True
   else False
 
+-- Approximate measure of the `DFAState`. Remark it does not take into
+-- account the size of the state. Maybe should be fixed
 measureDFAState :: DFAState -> Int
 measureDFAState s =
   helper (initIteratorDFAState s) 0
@@ -376,10 +378,8 @@ measureDFAState s =
       case nextIteratorDFAState qq of
         Nothing -> r
         Just (cfg, qs) ->
-          let iCtrl = SCfg.lengthSymbolicStack (SCfg.cfgCtrl cfg)
-              iSem = SCfg.lengthSymbolicStack (SCfg.cfgSem cfg)
-              newR = max iSem (max iCtrl r)
-          in helper qs newR
+          let measCfg = SCfg.measureSlkCfg cfg
+          in helper qs (max measCfg r)
 
 convertDFARegistryToDFAState :: DFARegistry -> DFAState
 convertDFARegistryToDFAState r =

--- a/src/Daedalus/ParserGen/LL/LLA.hs
+++ b/src/Daedalus/ParserGen/LL/LLA.hs
@@ -258,28 +258,28 @@ predictDFA dfa i =
       case lst of
         [] -> acc
         s : rest ->
-          let (backCfg, pdx) = extractPredictionFromDFARegistry src s
+          let (backCfg, pdx) = extractPredictionFromDFARegistry src (initIteratorDFARegistry s)
           in walkBackward backCfg rest ((Seq.><) pdx acc)
 
     extractSinglePrediction :: DFARegistry -> (SourceCfg, Prediction)
     extractSinglePrediction s =
-      case iterDFARegistry s of
+      case nextIteratorDFARegistry (initIteratorDFARegistry s) of
         Just (DFAEntry c1 (ClosurePath alts _c2 (_pos, _, _) _c3), rest) ->
-          if not (null rest)
+          if isEmptyIteratorDFARegistry rest
           then error "ambiguous prediction"
           else (c1, alts)
           -- NOTE: pos is appended because this is the last transition
         Just (DFAEntry c1 (ClosureAccepting alts _c2), rest) ->
-          if not (null rest)
+          if isEmptyIteratorDFARegistry rest
           then error "ambiguous prediction"
           else (c1, alts)
         Just (DFAEntry _c1 (ClosureMove {}), _) ->
           error "broken invariant: cannot be ClosureMove here"
         _ -> error "ambiguous prediction"
 
-    extractPredictionFromDFARegistry :: SourceCfg -> DFARegistry -> (SourceCfg, Prediction)
+    extractPredictionFromDFARegistry :: SourceCfg -> IteratorDFARegistry -> (SourceCfg, Prediction)
     extractPredictionFromDFARegistry src s =
-      case iterDFARegistry s of
+      case nextIteratorDFARegistry s of
         Nothing -> error "could not find src from previous cfg"
         Just (DFAEntry c1 (ClosurePath alts _c2 (_pos, _, _q2) c3), others) ->
           if cfgState c3 == cfgState src && cfgCtrl c3 == cfgCtrl src

--- a/src/Daedalus/ParserGen/LL/LLA.hs
+++ b/src/Daedalus/ParserGen/LL/LLA.hs
@@ -29,7 +29,7 @@ import Daedalus.ParserGen.Aut (Aut(..), Choice(..), stateToString, getMaxState)
 import Daedalus.ParserGen.LL.Result
 import Daedalus.ParserGen.LL.SlkCfg
 import Daedalus.ParserGen.LL.Closure
-import Daedalus.ParserGen.LL.DeterminizeOneStep
+import Daedalus.ParserGen.LL.DFAStep
 import Daedalus.ParserGen.LL.DFA
 
 

--- a/src/Daedalus/ParserGen/LL/LLA.hs
+++ b/src/Daedalus/ParserGen/LL/LLA.hs
@@ -494,8 +494,6 @@ statsLLA aut llas =
       let r = fromJust (lookupDFA (startDFA dfa) dfa)
       in
       case r of
-        Abort AbortAmbiguous -> result "-ambiguous-0"
-        Abort AbortOverflowK -> abortToString r
         Result _t ->
           let k = lookaheadDepth dfa
               res

--- a/src/Daedalus/ParserGen/LL/LLA.hs
+++ b/src/Daedalus/ParserGen/LL/LLA.hs
@@ -265,12 +265,12 @@ predictDFA dfa i =
     extractSinglePrediction s =
       case nextIteratorDFARegistry (initIteratorDFARegistry s) of
         Just (DFAEntry c1 (ClosurePath alts _c2 (_pos, _, _) _c3), rest) ->
-          if isEmptyIteratorDFARegistry rest
+          if not (isEmptyIteratorDFARegistry rest)
           then error "ambiguous prediction"
           else (c1, alts)
           -- NOTE: pos is appended because this is the last transition
         Just (DFAEntry c1 (ClosureAccepting alts _c2), rest) ->
-          if isEmptyIteratorDFARegistry rest
+          if not (isEmptyIteratorDFARegistry rest)
           then error "ambiguous prediction"
           else (c1, alts)
         Just (DFAEntry _c1 (ClosureMove {}), _) ->
@@ -410,10 +410,10 @@ createLLA aut =
 showStartSynthLLAState :: Aut a => a -> LLA -> SynthLLAState -> String
 showStartSynthLLAState aut dfas q =
   let dfaSt = fromJust $ Map.lookup q (mappingSynthToDFAState dfas) in
-  case iterDFAState dfaSt of
+  case nextIteratorDFAState (initIteratorDFAState dfaSt) of
     Nothing -> "__ZSINK_STATE"
     Just (cfg, qs) ->
-      if nullDFAState qs
+      if isEmptyIteratorDFAState qs
       then stateToString (cfgState cfg) aut ++ "\n" ++
            showSlkCfg cfg
       else error "broken invariant"

--- a/src/Daedalus/ParserGen/LL/Result.hs
+++ b/src/Daedalus/ParserGen/LL/Result.hs
@@ -5,41 +5,42 @@ module Daedalus.ParserGen.LL.Result
   , coerceAbort
   ) where
 
-import Daedalus.ParserGen.Action (Action(..))
-
 
 data AbortOption =
-    AbortNotStatic
-  | AbortNonClassInputAction Action
-  | AbortUnhandledAction
-  | AbortOverflowMaxDepth
-  | AbortLoopWithNonClass
-  | AbortNonEmptyIntersection
+    -- Abort cases for `SlkCfg`
+    AbortSlkCfgExecution
+
+    -- Abort cases for `Closure`
+  | AbortClosureUnhandledInputAction
+  | AbortClosureUnhandledAction
+  | AbortClosureOverflowMaxDepth
+  | AbortClosureInfiniteloop
+
+    -- Abort cases for `ClassInterval`
   | AbortClassIsDynamic
   | AbortClassNotHandledYet String
-  | AbortSymbolicExec
-  | AbortIncompatibleInput
-  | AbortOverflowCfg
 
-  | AbortAmbiguous
-  | AbortOverflowK
+    -- Abort cases for DFA
+  | AbortDFAIncompatibleInput
+  | AbortDFAOverflowInitCfg
+  | AbortDFAOverflowLookahead
 
 instance Show(AbortOption) where
   show a =
     case a of
-      AbortNotStatic -> "AbortNotStatic"
-      AbortNonClassInputAction _ -> "AbortNonClassInputAction"
-      AbortUnhandledAction -> "AbortUnhandledAction"
-      AbortOverflowMaxDepth -> "AbortOverflowMaxDepth"
-      AbortLoopWithNonClass -> "AbortLoopWithNonClass"
-      AbortNonEmptyIntersection -> "AbortNonEmptyIntersection"
+      AbortSlkCfgExecution -> "AbortSlkCfgExecution"
+
+      AbortClosureUnhandledInputAction -> "AbortClosureUnhandledInputAction"
+      AbortClosureUnhandledAction -> "AbortClosureUnhandledAction"
+      AbortClosureOverflowMaxDepth -> "AbortClosureOverflowMaxDepth"
+      AbortClosureInfiniteloop -> "AbortClosureInfiniteloop"
+
       AbortClassIsDynamic -> "AbortClassIsDynamic"
       AbortClassNotHandledYet str -> "AbortClassNotHandledYet-" ++ str
-      AbortSymbolicExec -> "AbortSymbolicExec"
-      AbortIncompatibleInput -> "AbortIncompatibleInput"
-      AbortOverflowCfg -> "AbortOverflowCfg"
-      AbortAmbiguous -> "AbortAmbiguous"
-      AbortOverflowK -> "AbortOverflowK"
+
+      AbortDFAIncompatibleInput -> "AbortDFAIncompatibleInput"
+      AbortDFAOverflowInitCfg -> "AbortDFAOverflowInitCfg"
+      AbortDFAOverflowLookahead -> "AbortDFAOverflowLookahead"
 
 data Result a =
     Abort AbortOption

--- a/src/Daedalus/ParserGen/LL/SlkCfg.hs
+++ b/src/Daedalus/ParserGen/LL/SlkCfg.hs
@@ -1,11 +1,10 @@
 {-# Language GADTs #-}
 
 module Daedalus.ParserGen.LL.SlkCfg
-  ( SymbolicStack(..),
-    lengthSymbolicStack,
-    SlkInput,
+  ( SlkInput,
     SlkCfg(..),
     compareSlkCfg,
+    measureSlkCfg,
     initSlkCfg,
     showSlkCfg,
     simulateActionSlkCfg,
@@ -247,6 +246,15 @@ instance Eq SlkCfg where
 instance Ord SlkCfg where
   compare c1 c2 = compareSlkCfg c1 c2
 
+
+-- An approximate measure of `SlkCfg`
+-- TODO: add the max with the Input
+measureSlkCfg :: SlkCfg -> Int
+measureSlkCfg cfg =
+  let
+    iCtrl = lengthSymbolicStack (cfgCtrl cfg)
+    iSem = lengthSymbolicStack (cfgSem cfg)
+  in max iCtrl iSem
 
 initSlkCfg :: State -> SlkCfg
 initSlkCfg q =

--- a/src/Daedalus/ParserGen/LL/SlkCfg.hs
+++ b/src/Daedalus/ParserGen/LL/SlkCfg.hs
@@ -531,7 +531,7 @@ symbExecInp act ctrl out inp =
       let ev = symbolicEval name ctrl out in
       case ev of
         SConcrete (Right x) -> R.Result $ Just (x, SCons (SlkSEVal (SConcrete (Left defaultValue))) out)
-        Wildcard -> R.Abort R.AbortSymbolicExec
+        Wildcard -> R.Abort R.AbortSlkCfgExecution
         _ -> -- trace (show ev) $
              error "TODO"
     StreamLen _s e1 e2 ->
@@ -542,10 +542,10 @@ symbExecInp act ctrl out inp =
           SConcrete (Left (Interp.VInteger n)) ->
             case ev2 of
               SConcrete (Right x) -> R.Result $ Just (inp, SCons (SlkSEVal (SConcrete (Right $ InpTake (fromIntegral n) x))) out)
-              Wildcard -> R.Abort R.AbortSymbolicExec
+              Wildcard -> R.Abort R.AbortSlkCfgExecution
               _ -> error "TODO"
           _ -> -- trace "nont integer const" $
-            R.Abort R.AbortSymbolicExec
+            R.Abort R.AbortSlkCfgExecution
     StreamOff _s e1 e2 ->
       let ev1 = symbolicEval e1 ctrl out
           ev2 = symbolicEval e2 ctrl out
@@ -555,9 +555,9 @@ symbExecInp act ctrl out inp =
             case ev2 of
               SConcrete (Right x) ->
                 R.Result $ Just (inp, SCons (SlkSEVal (SConcrete (Right $ InpDrop (fromIntegral n) x))) out)
-              Wildcard -> R.Abort R.AbortSymbolicExec
+              Wildcard -> R.Abort R.AbortSlkCfgExecution
               _ -> error "TODO"
-          _ -> R.Abort R.AbortSymbolicExec
+          _ -> R.Abort R.AbortSlkCfgExecution
 
     _ -> error "TODO"
 
@@ -619,7 +619,7 @@ simulateActionSlkCfg aut act q2 cfg =
             , cfgInput = newInp
             }
           ]
-        R.Abort R.AbortSymbolicExec -> R.Abort R.AbortSymbolicExec
+        R.Abort R.AbortSlkCfgExecution -> R.Abort R.AbortSlkCfgExecution
         _ -> error "impossible"
     _ ->
       R.Result $ Just

--- a/tests/parser-gen/D010.test.stdout
+++ b/tests/parser-gen/D010.test.stdout
@@ -21,14 +21,14 @@ DTrans [
 
 Main (28,10)-(28,41)
 SlkCfg{ q:180, ctrl:[?, *], sem:[?, ], inp:---[2..] }
-AbortIncompatibleInput
+AbortDFAIncompatibleInput
 
 
 **********************
 **** Extended LLA ****
 **********************
-("AbortIncompatibleInput",4)
-("AbortSymbolicExec",8)
+("AbortDFAIncompatibleInput",4)
+("AbortSlkCfgExecution",8)
 ("Result-0",2)
 ("Result-1",1)
 ("Result-2",3)
@@ -38,7 +38,7 @@ Total nb states: 18
 **********************
 ***** Strict LLA *****
 **********************
-("AbortIncompatibleInput",1)
+("AbortDFAIncompatibleInput",1)
 ("Result-2",1)
 
 Total nb states: 2
@@ -48,6 +48,6 @@ Warning: LL(*) failures:
 
 Main (28,10)-(28,41)
 SlkCfg{ q:180, ctrl:[?, *], sem:[?, ], inp:---[2..] }
-AbortIncompatibleInput
+AbortDFAIncompatibleInput
 
 

--- a/tests/parser-gen/D014.todo.test.stdout
+++ b/tests/parser-gen/D014.todo.test.stdout
@@ -173,14 +173,14 @@ DTrans [
 
 SkipTo__11 (7,32)-(7,39)
 SlkCfg{ q:20, ctrl:[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, *], sem:[?, ], inp:--- }
-AbortOverflowCfg
+AbortDFAOverflowInitCfg
 
 
 **********************
 **** Extended LLA ****
 **********************
-("AbortLoopWithNonClass",2)
-("AbortOverflowCfg",3)
+("AbortClosureInfiniteloop",2)
+("AbortDFAOverflowInitCfg",3)
 ("Result-1",1)
 ("abort-1",12)
 ("abort-2",21)
@@ -190,7 +190,7 @@ Total nb states: 39
 **********************
 ***** Strict LLA *****
 **********************
-("AbortOverflowCfg",1)
+("AbortDFAOverflowInitCfg",1)
 ("abort-2",10)
 
 Total nb states: 11
@@ -370,6 +370,6 @@ DTrans [
 
 SkipTo__11 (7,32)-(7,39)
 SlkCfg{ q:20, ctrl:[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, *], sem:[?, ], inp:--- }
-AbortOverflowCfg
+AbortDFAOverflowInitCfg
 
 


### PR DESCRIPTION
During the construction of an LL(*) automaton, the internal representation of the states is a subset of states of the original NFA but also an abstracted version of the various contextual inputs, control and semantic stacks. The comparison operation of these abstract representations is pervasive and costly when the comparison is done naively using its structure, so this PR implements the comparison more efficiently using some hashconsing.
The changes proposed here are just to get started on using hashconsing and the generic SlkStack datastructure what the profiler showed would benefit most from optimization. Applying the technique more completely is outside the scope of this PR and will be decided as needed based on performance requirements.