### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM haskell:8.8.3
+  
+COPY . /daedalus
+WORKDIR /daedalus
+
+RUN cabal update
+# Use copy instead of symlink because we are root right now
+RUN cabal install exe:daedalus --installdir=/usr/local/bin --install-method=copy
+
+


### PR DESCRIPTION
This Dockerfile can be used to create an image with daedalus built and installed. It currently uses GHC 8.8.3 and Cabal 3.2 as recommended in the `README`. It builds on the official [`haskell:8.8.3` image](https://hub.docker.com/layers/haskell/library/haskell/8.8.3/images/sha256-08d9abf330305268bf77b251cd41d04372536712d495122bc6c8d054dbdfe3c0) which is (currently) based on Debian 10 (Buster).

The following steps should do the trick:

- Checkout from git the branch or version of daedalus that you intend to build
- From the main directory, do `docker build -t galoisinc/daedalus .` to create the image with the tag `galoisinc/daedalus`

The resulting image will have daedalus installed in `/usr/local/bin`
