### PR TITLE
pdf-driver: add missing extra-source-files

### DIFF
--- a/pdf-driver/pdf-driver.cabal
+++ b/pdf-driver/pdf-driver.cabal
@@ -13,13 +13,16 @@ copyright:           2019, Galois Inc
 build-type:          Custom
 extra-source-files:
   CHANGELOG.md,
+  spec/ContentStreamLight.ddl,
+  spec/ISOCodes.ddl,
+  spec/PdfContentStream.ddl,
   spec/PdfDecl.ddl,
   spec/PdfDemo.ddl,
-  spec/ISOCodes.ddl,
+  spec/PdfDOM.ddl,
   spec/PdfText.ddl,
   spec/PdfValidate.ddl,
-  spec/PdfDOM.ddl,
   spec/Stdlib.ddl,
+  spec/Unicode.ddl,
 
 -- This is the compiler: it generates the sources in `pdf-spec`
 custom-setup


### PR DESCRIPTION
These files are necessary for the build to work, and not listed in
extra-source-files.  Note that there are a couple other files in the spec/
directory that are not listed, but are not critical to the build.  You might
want them listed too.