### PR TITLE
daedalus: avoid accidental Haddock comments

### DIFF
--- a/src/Daedalus/ParserGen/LL/LLA.hs
+++ b/src/Daedalus/ParserGen/LL/LLA.hs
@@ -564,7 +564,7 @@ printLLA aut lla cond =
             if
               ( cond dfa
                 -- (lookaheadDepth dfa < 10)
-                -- ||
+                --  ||
                 -- (fromJust $ flagHasFullResolution dfa)
               )
             then

--- a/src/Daedalus/Type/CheckUnused.hs
+++ b/src/Daedalus/Type/CheckUnused.hs
@@ -22,8 +22,8 @@ checkTCDecl TCDecl { tcDeclCtxt, tcDeclDef } =
 
 checkTC :: Bool -> TC SourceRange Grammar -> [SourceRange]
 checkTC triv tc =
-  -- | trace (show (triv, pp tc)) False = undefined
-  -- | otherwise =
+  --  | trace (show (triv, pp tc)) False = undefined
+  --  | otherwise =
   let warnIf b = if b then [ texprAnnot tc ] else []
       okLeaf   = []
   in


### PR DESCRIPTION
Commented-out lines that start with a `|` look like the beginning of Haddock
documentation comments, and make it so that Haddock fails to build
documentation for this project.  Adding a whitespace is enough to keep it
happy.