### PR TITLE
vscode: add configuration

### DIFF
--- a/syntax-highlight/vscode-daedalus/package.json
+++ b/syntax-highlight/vscode-daedalus/package.json
@@ -14,6 +14,16 @@
     ],
     "main": "./out/extension.js",
     "contributes": {
+        "configuration": {
+            "title": "Daedalus configuration",
+            "properties": {
+                "daedalus.language-server-path": {
+                    "type": "string",
+                    "default": "daedalus-language-server",
+                    "description": "Path to the Daedalus language server"
+                }
+            }
+        },
         "languages": [{
             "id": "daedalus",
             "aliases": ["Daedalus", "daedalus"],

--- a/syntax-highlight/vscode-daedalus/src/configuration.ts
+++ b/syntax-highlight/vscode-daedalus/src/configuration.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode'
+
+const configurationName = 'daedalus'
+
+export const configLanguageServerPath = 'language-server-path'
+
+export type Configuration = {
+    [configLanguageServerPath]: string
+}
+
+export function getConfiguration(): Configuration {
+    return vscode.workspace.getConfiguration(configurationName) as any
+}

--- a/syntax-highlight/vscode-daedalus/src/extension.ts
+++ b/syntax-highlight/vscode-daedalus/src/extension.ts
@@ -13,15 +13,22 @@ import {
 	TransportKind
 } from 'vscode-languageclient/node';
 
+import {
+	configLanguageServerPath,
+	getConfiguration,
+} from './configuration'
+
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
-	// The server is implemented in node
-	let serverExecutable = 
-		path.join('Users', 'sjw', 'galois', 'safedocs', 'daedalus', 'daedalus-language-server', 'server-wrapper.sh');
+
+	const configuration = getConfiguration()
+
+	let serverExecutable = configuration[configLanguageServerPath]
+
 	// If the extension is launched in debug mode then the debug server options are used
 	// Otherwise the run options are used
-	
+
 	let serverOptions: ServerOptions = {
 		run: { command: serverExecutable, transport: TransportKind.stdio },
 		debug: { command: serverExecutable, transport: TransportKind.stdio }
@@ -29,7 +36,6 @@ export function activate(context: ExtensionContext) {
 
 	// Options to control the language client
 	let clientOptions: LanguageClientOptions = {
-		// Register the server for plain text documents
 		documentSelector: [{ scheme: 'file', language: 'daedalus' }]
 	};
 


### PR DESCRIPTION
This adds a Daedalus configuration section for the VSCode extension.  For now
there is just one option "daedalus.language-server-path", to set the path of
the executable that should be run as a language server.

Note that extension.ts uses Windows-style line endings (CRLF), which I think I
am respecting in my changes, but in this commit, the new configuration.ts uses
Unix-style line endings (LF).  Should CRLF be preferred?

I also removed comments that seem like they were copy-pasted from some example
code and are not accurate to this project.