### PR TITLE
Use an explicit notation for local type variables (`?x`).

### DIFF
--- a/icc-driver/Setup.hs
+++ b/icc-driver/Setup.hs
@@ -7,6 +7,7 @@ import Distribution.Simple.Setup
 import Distribution.Types.HookedBuildInfo
 
 import qualified Data.Map as Map
+import Control.Exception(catch)
 
 import Daedalus.Driver
 import Daedalus.Type.AST
@@ -33,6 +34,7 @@ compileDDL =
      mapM_ (\m -> do ph <- ddlGetPhase m
                      ddlPrint (phasePass ph)
                      saveHS (Just "src") cfg m) todo
+  `catch` \d -> putStrLn =<< prettyDaedalusError d
 
   where
   -- This would be used if we specialized

--- a/icc-driver/icc-driver.cabal
+++ b/icc-driver/icc-driver.cabal
@@ -1,4 +1,4 @@
-cabal-version:       >=1.10
+cabal-version:       >=2.0
 
 name:                icc-driver
 version:             0.1.0.0
@@ -8,12 +8,13 @@ maintainer:          iavor.diatchki@gmail.com
 build-type:          Custom
 extra-source-files:
   CHANGELOG.md
-  spec/ICC.ddl
+  specs/ICC.ddl
 
 custom-setup
   setup-depends: base, containers, daedalus, Cabal
 
 executable icc-parser
+  default-language: Haskell2010
   main-is: Main.hs
   other-modules: ICC
   hs-source-dirs: src

--- a/icc-driver/icc-driver.cabal
+++ b/icc-driver/icc-driver.cabal
@@ -6,7 +6,9 @@ license-file:        LICENSE
 author:              Iavor Diatchki
 maintainer:          iavor.diatchki@gmail.com
 build-type:          Custom
-extra-source-files:  CHANGELOG.md
+extra-source-files:
+  CHANGELOG.md
+  spec/ICC.ddl
 
 custom-setup
   setup-depends: base, containers, daedalus, Cabal

--- a/icc-driver/specs/ICC.ddl
+++ b/icc-driver/specs/ICC.ddl
@@ -152,7 +152,7 @@ def Response16Number = {
 
 def TagTable = {
   @tag_count = BE32;
-  Many (tag_count as size) TagEntry;
+  Many (tag_count as uint 64) TagEntry;
 }
 
 def TagEntry = {
@@ -163,8 +163,8 @@ def TagEntry = {
 
 -- ENTRY: Should only be used when the stream is at offset 0
 def ParseTag (t : TagEntry) = {
-  Goto (t.offset_to_data_element as size);
-  ParseChunk (t.size_of_data_element as size) (Tag t.tag_signature);
+  Goto (t.offset_to_data_element as uint 64);
+  ParseChunk (t.size_of_data_element as uint 64) (Tag t.tag_signature);
 }
 
 
@@ -275,7 +275,7 @@ def MultiLocalizedUnicodeType = {
   @record_number = BE32;
   @record_size   = BE32;
   Guard (record_size == 12);
-  Many (record_number as size) (UnicodeRecord s);
+  Many (record_number as uint 64) (UnicodeRecord s);
 }
 
 def UnicodeRecord s = {
@@ -283,7 +283,7 @@ def UnicodeRecord s = {
   country  = BE16;
   @size    = BE32;
   @offset  = BE32;
-  data     = Remote (ChunkRelativeTo s (offset as size) (size as size));
+  data     = Remote (ChunkRelativeTo s (offset as uint 64) (size as uint 64));
 }
 
 def S15Fixed16ArrayType = {
@@ -295,7 +295,7 @@ def ChromaticityType = {
   StartTag "chrm";
   @number_of_device_channels = BE16;
   phosphor_or_colorant       = BE16;
-  cie_coords                 = Many (number_of_device_channels as size) XYNumber;
+  cie_coords                 = Many (number_of_device_channels as uint 64) XYNumber;
 }
 
 def ColorantOrderType = {
@@ -307,7 +307,7 @@ def ColorantOrderType = {
 def ColorantTableType = {
   StartTag "clrt";
   @count_of_colorant = BE32;
-  Many (count_of_colorant as size) Colorant;
+  Many (count_of_colorant as uint 64) Colorant;
 }
 
 def Colorant = {
@@ -318,7 +318,7 @@ def Colorant = {
 def CurveType = {
   StartTag "curv";
   @n = BE32;
-  Many (n as size) BE16;
+  Many (n as uint 64) BE16;
 }
 
 def ParametricCurveType = {
@@ -334,9 +334,9 @@ def ResponseCurveSet16Type = {
   StartTag "rcs2";
   @number_of_channels = BE16;
   @count              = BE16;
-  Many (count as size) {
+  Many (count as uint 64) {
     @off  = BE32;
-    Remote { GotoRel s (off as size); ResponseCurve (number_of_channels as size)};
+    Remote { GotoRel s (off as uint 64); ResponseCurve (number_of_channels as uint 64)};
   }
 }
 
@@ -344,17 +344,17 @@ def ResponseCurve n = {
   measurement_unit  = BE32;
   @counts           = Many n BE32;
   pcxyzs            = Many n XYNumber;
-  response_arrays   = map (qi in counts) (Many (qi as size) Response16Number)
+  response_arrays   = map (qi in counts) (Many (qi as uint 64) Response16Number)
 }
 
 def Lut8Type = {
   StartTag "mft1";
   number_of_input_channels = UInt8;
-  @i = ^ number_of_input_channels as size;
+  @i = ^ number_of_input_channels as uint 64;
   number_of_output_channels = UInt8;
-  @o = ^ number_of_output_channels as size;
+  @o = ^ number_of_output_channels as uint 64;
   number_of_clut_grid_points = UInt8;
-  @g = number_of_clut_grid_points as size;
+  @g = number_of_clut_grid_points as uint 64;
   Match1 0x00;
   encoded_e_parameters = Many 9 { @x = BE32; ^ x as! sint 32 };
   input_tables  = Chunk (256 * i);
@@ -365,17 +365,17 @@ def Lut8Type = {
 def Lut16Type = {
   StartTag "mft2";
   number_of_input_channels = UInt8;
-  @i = ^ number_of_input_channels as size;
+  @i = ^ number_of_input_channels as uint 64;
   number_of_output_channels = UInt8;
-  @o = ^ number_of_output_channels as size;
+  @o = ^ number_of_output_channels as uint 64;
   number_of_clut_grid_points = UInt8;
-  @g = number_of_clut_grid_points as size;
+  @g = number_of_clut_grid_points as uint 64;
   Match1 0x00;
   encoded_e_parameters = Many 9 { @x = BE32; ^ x as! sint 32 };
   number_of_input_table_entries = BE32;
-  @n = ^ number_of_input_table_entries as size;
+  @n = ^ number_of_input_table_entries as uint 64;
   number_of_output_table_entries = BE32;
-  @m = ^ number_of_output_table_entries as size;
+  @m = ^ number_of_output_table_entries as uint 64;
   input_tables  = Chunk (256 * n * i);
   clut_values   = Chunk (2 * (exp g i) * o);
   output_tables = Chunk (2 * m * o);
@@ -415,11 +415,11 @@ def MultiProcessElementsType = {
   number_of_input_channels      = BE16;
   number_of_output_channels     = BE16;
   number_of_processing_elements = BE32;
-  n = ^ number_of_processing_elements as size;
+  n = ^ number_of_processing_elements as uint 64;
   Guard (n > 0);
   @els = Many n PositionNumber;
   elements = map (e in els)
-                 (ChunkRelativeTo s (e.offset as size) (e.size as size));
+                 (ChunkRelativeTo s (e.offset as uint 64) (e.size as uint 64));
 }
 
 
@@ -448,7 +448,7 @@ def NamedColor2Type = {
   @number_of_coords = BE32;
   prefix            = ParseChunk 32 (Only ASCII7);
   suffix            = ParseChunk 32 (Only ASCII7);
-  names             = Many (count as size) (ColorName (number_of_coords as size));
+  names             = Many (count as uint 64) (ColorName (number_of_coords as uint 64));
 }
 
 def ColorName m = {

--- a/pdf-cos/Setup.hs
+++ b/pdf-cos/Setup.hs
@@ -4,8 +4,9 @@
 import Distribution.Simple
 import Distribution.Simple.Setup
 import Distribution.Types.HookedBuildInfo
-
+import Control.Exception(catch)
 import qualified Data.Map as Map
+
 import Daedalus.Driver
 import Daedalus.Type.AST
 import Daedalus.Compile.LangHS
@@ -32,6 +33,7 @@ compileDDL =
                       "PdfDecl"     -> cfgPdfDecl
                       _             -> cfg
      mapM_ (\m -> saveHS (Just "src") (cfgFor m) m) todo
+  `catch` \d -> putStrLn =<< prettyDaedalusError d
 
   where
   -- XXX: This shoudl list all parsers we need, and it'd be used if

--- a/pdf-cos/spec/PdfDecl.ddl
+++ b/pdf-cos/spec/PdfDecl.ddl
@@ -32,7 +32,7 @@ def Stream (val : Value) = {
 -- lookup refs (could also ignore that part of the xref entry and just
 -- lookup the ref)
 
-def ObjectStreamEntry (oid : Nat) = {
+def ObjectStreamEntry (oid : int) = {
   oid = ^ oid;
   val = Value; -- FIXME: we should check this isn't a ref etc?  (c.f. pdf 1.7, pg 101)
 }
@@ -52,7 +52,7 @@ def ObjectStream (n : uint 64) (first : uint 64) = {
   };
 }
 
-def ObjectStreamNth (n : uint 64) (first : Nat) (idx : Nat) = {
+def ObjectStreamNth (n : uint 64) (first : uint 64) (idx : uint 64) = {
   -- FIXME: only really need to parse up to idx
   @meta  = Many n (ObjStreamMeta first);
   @entry = Index meta idx;
@@ -71,7 +71,7 @@ def SkipBytes n = Chunk n {}
 -- For values this means we should return 'null'.
 def ResolveRef (r : Ref) : maybe TopDecl
 
-def CheckExpected (r : ref) (d : TopDecl) = {
+def CheckExpected (r : Ref) (d : TopDecl) = {
   Guard (d.id  == r.obj && d.gen == r.gen);
   ^ d.obj;
 }
@@ -96,7 +96,7 @@ def ResolveObjectStream (v : Value) : [ ObjectStreamEntry ] = {
 }
 
 def ResolveObjectStreamEntry
-      (oid : Nat) (gen : Nat) (idx : uint 64) : TopDecl = {
+      (oid : int) (gen : int) (idx : uint 64) : TopDecl = {
   @stm = ResolveStream {| ref = { obj = oid; gen = gen } |};
   CheckType "ObjStm" stm.header;
   @n       = LookupSize "N"     stm.header;

--- a/pdf-driver/Setup.hs
+++ b/pdf-driver/Setup.hs
@@ -4,6 +4,7 @@
 import Distribution.Simple
 import Distribution.Simple.Setup
 import Distribution.Types.HookedBuildInfo
+import Control.Exception(catch)
 
 import qualified Data.Map as Map
 import Daedalus.Driver
@@ -28,13 +29,15 @@ compileDDL :: IO ()
 compileDDL =
   daedalus
   do ddlSetOpt optSearchPath ["spec"]
-     let mods = [ "PdfDemo", "PdfValidate", "PdfDOM", "PdfContentStream" ]
+     let mods = [ "PdfDemo", "PdfValidate", "PdfDOM", "PdfContentStream"
+                , "ContentStreamLight" ]
      mapM_ ddlLoadModule mods
      todo <- filter (not . (`elem` external)) <$> ddlBasisMany mods
      let cfgFor m = case m of
                       "PdfValidate" -> cfgPdfValidate
                       _             -> cfg
      mapM_ (\m -> saveHS (Just "src/spec") (cfgFor m) m) todo
+  `catch` \d -> putStrLn =<< prettyDaedalusError d
 
   where
 

--- a/pdf-driver/pdf-driver.cabal
+++ b/pdf-driver/pdf-driver.cabal
@@ -20,6 +20,8 @@ extra-source-files:
   spec/PdfValidate.ddl,
   spec/PdfDOM.ddl,
   spec/Stdlib.ddl,
+  spec/PdfContentStream.ddl,
+  spec/ContentStreamLight.ddl
 
 -- This is the compiler: it generates the sources in `pdf-spec`
 custom-setup
@@ -35,12 +37,18 @@ library
   exposed-modules:
     PdfDemo,
     PdfValidate,
-    PdfDOM
+    PdfDOM,
+    PdfContentStream,
+    ContentStreamLight,
+    Unicode
 
   autogen-modules:
     PdfDemo,
     PdfValidate,
-    PdfDOM
+    PdfDOM,
+    PdfContentStream,
+    ContentStreamLight,
+    Unicode
 
   build-depends:
     base >=4.13 && <4.15,

--- a/pdf-driver/spec/PdfDOM.ddl
+++ b/pdf-driver/spec/PdfDOM.ddl
@@ -4,6 +4,7 @@ import PdfValue
 import PdfValidate
 
 import PdfDecl
+import PdfXRef
 
 def PdfTrailer (t : TrailerDict) =
   CheckRef "Catalog" PdfCatalog (t.root is just)

--- a/pdf-driver/spec/PdfDemo.ddl
+++ b/pdf-driver/spec/PdfDemo.ddl
@@ -80,7 +80,7 @@ def TopDeclCheck expectId expectGen = {
 }
 
 def ResolveObjectStreamEntryCheck
-      expectId expectGen (oid : Nat) (gen : Nat) (idx : Nat) = {
+      expectId expectGen (oid : int) (gen : int) (idx : uint 64) = {
   @decl = ResolveObjectStreamEntry oid gen idx;
   CheckDecl expectId expectGen decl;
 }

--- a/src/Daedalus/AST.hs
+++ b/src/Daedalus/AST.hs
@@ -360,7 +360,8 @@ data TypeF t =
   | TMap   !t !t
     deriving (Eq,Show,Functor,Foldable,Traversable)
 
-data SrcType = SrcVar Name
+data SrcType = SrcVar (Located Text)
+             | SrcCon Name
              | SrcType (Located (TypeF SrcType))
               deriving Show
 
@@ -378,6 +379,7 @@ instance HasRange SrcType where
   range ty =
     case ty of
       SrcVar x -> range x
+      SrcCon x -> range x
       SrcType x -> range x
 
 instance HasRange Pattern where
@@ -512,6 +514,7 @@ instance OrdF Context where
 instance PP SrcType where
   ppPrec n ty = case ty of
                   SrcVar x -> ppPrec n x
+                  SrcCon x -> ppPrec n x
                   SrcType l -> ppPrec n (thingValue l)
 
 

--- a/src/Daedalus/Parser/Grammar.y
+++ b/src/Daedalus/Parser/Grammar.y
@@ -536,7 +536,8 @@ type                                     :: { SrcType }
   | '[' arr_or_map ']'                      { atT ($1 <-> $3) $2 }
   | '{' '}'                                 { atT ($1 <-> $2) TUnit }
   | NUMBER                                  { atT (fst $1) (TNum (fst (snd $1))) }
-  | name                                    { SrcVar $1 }
+  | name                                    { SrcCon $1 }
+  | SMALLIDENTI                             { SrcVar (loc (fst $1) (snd $1)) }
 
 arr_or_map                               :: { TypeF SrcType }
   : type                                    { TArray $1 }

--- a/src/Daedalus/Scope.hs
+++ b/src/Daedalus/Scope.hs
@@ -367,8 +367,8 @@ instance ResolveNames t => ResolveNames (Located t) where
 instance ResolveNames SrcType where
   resolve ty =
     case ty of
-      -- FIXME: should we treat tvs differently?
-      SrcVar x   -> SrcVar  <$> resolve x
+      SrcVar x   -> pure (SrcVar x)
+      SrcCon x   -> SrcCon  <$> resolve x
       SrcType tf -> SrcType <$> resolve tf
 
 resolveStructFields :: ResolveNames e => [StructField e] -> ScopeM [StructField e]

--- a/src/Daedalus/Type/Monad.hs
+++ b/src/Daedalus/Type/Monad.hs
@@ -77,6 +77,7 @@ module Daedalus.Type.Monad
   ) where
 
 
+import Data.Text(Text)
 import Data.Map(Map)
 import qualified Data.Map as Map
 import Data.Set(Set)
@@ -427,7 +428,7 @@ data RO ctx = RO
   }
 
 data RW = RW
-  { sLocalTyVars  :: !(Map Name Type) -- ^ Names for local types (from sigs)
+  { sLocalTyVars  :: !(Map Text Type) -- ^ Names for local types (from sigs)
   , sNextType     :: !Int             -- ^ Used to generate variants of the root
   , sIPUsed       :: !(Set IPName)
     -- ^ IPs (from the ones in scope) that were used.  We keep track of this
@@ -488,10 +489,10 @@ arePartialAppsOK :: TypeM ctx Bool
 arePartialAppsOK = TypeM (allowPartial <$> ask)
 
 
-lookupLocalTyVar :: Name -> TypeM ctx (Maybe Type)
+lookupLocalTyVar :: Text -> TypeM ctx (Maybe Type)
 lookupLocalTyVar x = TypeM (Map.lookup x . sLocalTyVars <$> get)
 
-newLocalTyVar :: Name -> Type -> TypeM ctx ()
+newLocalTyVar :: Text -> Type -> TypeM ctx ()
 newLocalTyVar x t =
   TypeM (sets_ \s -> s { sLocalTyVars = Map.insert x t (sLocalTyVars s) })
 

--- a/tests/T044.ddl
+++ b/tests/T044.ddl
@@ -3,7 +3,7 @@ def a = { x = true }
 def b = { x = true } : a
 def c = { x = true }
 def d = { x = true } : d
-def e = { x = { x = true } : local; y = { x = true } : local }
+def e = { x = { x = true } : ?local; y = { x = true } : ?local }
 def f (i : a) = i.x
 
 
@@ -11,8 +11,8 @@ def A = Choose { x = Match1 1; y = Match1 2 }
 def B = Choose { x = Match1 3; y = Match1 4 } : A
 def C = Choose { x = Match1 1; y = Match1 2 }
 def D = Choose { x = Match1 1; y = Match1 2 } : D
-def E = { x = Choose { x = Match1 1; y = Match1 2 } : local;
-          y = Choose { x = Match1 1; y = Match1 3 } : local
+def E = { x = Choose { x = Match1 1; y = Match1 2 } : ?local;
+          y = Choose { x = Match1 1; y = Match1 3 } : ?local
         }
 
 def F (i : A) = i is x

--- a/tests/T044.ddl.stdout
+++ b/tests/T044.ddl.stdout
@@ -3,15 +3,8 @@ module T044
 --- Imports:
  
 --- Type defs:
-type T044.e0 = { x: bool
-               }
- 
 type T044.e1 = { x: bool
                }
- 
-type T044.E0 = Choose { y: uint 8
-                      ; x: uint 8
-                      }
  
 type T044.E1 = Choose { x: uint 8
                       ; y: uint 8
@@ -26,7 +19,7 @@ type T044.c = { x: bool
 type T044.d = { x: bool
               }
  
-type T044.e = { x: T044.e0
+type T044.e = { x: T044.e1
               ; y: T044.e1
               }
  
@@ -42,7 +35,7 @@ type T044.D = Choose { x: uint 8
                      ; y: uint 8
                      }
  
-type T044.E = { x: T044.E0
+type T044.E = { x: T044.E1
               ; y: T044.E1
               }
  
@@ -69,55 +62,55 @@ T044.f (i : T044.a) : bool =
  
 T044.A : Grammar T044.A =
   Choose fair
+    { {- x -} do (_24 : uint 8) <- Match {'\SOH'}
+                 pure {x: _24}
+    | {- y -} do (_25 : uint 8) <- Match {'\STX'}
+                 pure {y: _25}
+    }
+ 
+T044.B : Grammar T044.A =
+  Choose fair
+    { {- x -} do (_26 : uint 8) <- Match {'\ETX'}
+                 pure {x: _26}
+    | {- y -} do (_27 : uint 8) <- Match {'\EOT'}
+                 pure {y: _27}
+    }
+ 
+T044.C : Grammar T044.C =
+  Choose fair
     { {- x -} do (_28 : uint 8) <- Match {'\SOH'}
                  pure {x: _28}
     | {- y -} do (_29 : uint 8) <- Match {'\STX'}
                  pure {y: _29}
     }
  
-T044.B : Grammar T044.A =
+T044.D : Grammar T044.D =
   Choose fair
-    { {- x -} do (_30 : uint 8) <- Match {'\ETX'}
+    { {- x -} do (_30 : uint 8) <- Match {'\SOH'}
                  pure {x: _30}
-    | {- y -} do (_31 : uint 8) <- Match {'\EOT'}
+    | {- y -} do (_31 : uint 8) <- Match {'\STX'}
                  pure {y: _31}
     }
  
-T044.C : Grammar T044.C =
-  Choose fair
-    { {- x -} do (_32 : uint 8) <- Match {'\SOH'}
-                 pure {x: _32}
-    | {- y -} do (_33 : uint 8) <- Match {'\STX'}
-                 pure {y: _33}
-    }
- 
-T044.D : Grammar T044.D =
-  Choose fair
-    { {- x -} do (_34 : uint 8) <- Match {'\SOH'}
-                 pure {x: _34}
-    | {- y -} do (_35 : uint 8) <- Match {'\STX'}
-                 pure {y: _35}
-    }
- 
 T044.E : Grammar T044.E =
-  do (x : T044.E0) <- Choose fair
-                        { {- x -} do (_36 : uint 8) <- Match {'\SOH'}
-                                     pure {x: _36}
-                        | {- y -} do (_37 : uint 8) <- Match {'\STX'}
-                                     pure {y: _37}
+  do (x : T044.E1) <- Choose fair
+                        { {- x -} do (_32 : uint 8) <- Match {'\SOH'}
+                                     pure {x: _32}
+                        | {- y -} do (_33 : uint 8) <- Match {'\STX'}
+                                     pure {y: _33}
                         }
      (y : T044.E1) <- Choose fair
-                        { {- x -} do (_38 : uint 8) <- Match {'\SOH'}
-                                     pure {x: _38}
-                        | {- y -} do (_39 : uint 8) <- Match {'\ETX'}
-                                     pure {y: _39}
+                        { {- x -} do (_34 : uint 8) <- Match {'\SOH'}
+                                     pure {x: _34}
+                        | {- y -} do (_35 : uint 8) <- Match {'\ETX'}
+                                     pure {y: _35}
                         }
      pure {x = x,
            y = y}
  
 T044.F (i : T044.A) : Grammar (uint 8) =
   case i is
-    { {| x = _40 |} -> pure _40
+    { {| x = _36 |} -> pure _36
     }
  
 T044._A : Grammar {} =
@@ -156,5 +149,5 @@ T044._E : Grammar {} =
  
 T044._F (i : T044.A) : Grammar {} =
   case i is
-    { {| x = _40 |} -> pure {}
+    { {| x = _36 |} -> pure {}
     }

--- a/tests/formats/icc.test.stdout
+++ b/tests/formats/icc.test.stdout
@@ -287,130 +287,130 @@ ICC.VersionField : Grammar ICC.VersionField =
  
 ICC.ProfileClasses : Grammar ICC.ProfileClasses =
   do ($$ : ICC.ProfileClasses) <- Choose biased
-                                    { {- input_device_profile -} do (_262 : {}) <- @MatchBytes "scnr"
-                                                                    pure {input_device_profile: _262}
-                                    | {- display_device_profile -} do (_263 : {}) <- @MatchBytes "mntr"
-                                                                      pure {display_device_profile: _263}
-                                    | {- output_device_profile -} do (_264 : {}) <- @MatchBytes "prtr"
-                                                                     pure {output_device_profile: _264}
-                                    | {- device_link_profile -} do (_265 : {}) <- @MatchBytes "link"
-                                                                   pure {device_link_profile: _265}
-                                    | {- color_space_profile -} do (_266 : {}) <- @MatchBytes "spac"
-                                                                   pure {color_space_profile: _266}
-                                    | {- abstract_profile -} do (_267 : {}) <- @MatchBytes "abst"
-                                                                pure {abstract_profile: _267}
-                                    | {- named_color_profile -} do (_268 : {}) <- @MatchBytes "nmcl"
-                                                                   pure {named_color_profile: _268}
+                                    { {- input_device_profile -} do (_238 : {}) <- @MatchBytes "scnr"
+                                                                    pure {input_device_profile: _238}
+                                    | {- display_device_profile -} do (_239 : {}) <- @MatchBytes "mntr"
+                                                                      pure {display_device_profile: _239}
+                                    | {- output_device_profile -} do (_240 : {}) <- @MatchBytes "prtr"
+                                                                     pure {output_device_profile: _240}
+                                    | {- device_link_profile -} do (_241 : {}) <- @MatchBytes "link"
+                                                                   pure {device_link_profile: _241}
+                                    | {- color_space_profile -} do (_242 : {}) <- @MatchBytes "spac"
+                                                                   pure {color_space_profile: _242}
+                                    | {- abstract_profile -} do (_243 : {}) <- @MatchBytes "abst"
+                                                                pure {abstract_profile: _243}
+                                    | {- named_color_profile -} do (_244 : {}) <- @MatchBytes "nmcl"
+                                                                   pure {named_color_profile: _244}
                                     }
      pure $$
  
 ICC.DataColorSpaces : Grammar ICC.DataColorSpaces =
   do ($$ : ICC.DataColorSpaces) <- Choose biased
-                                     { {- nciexyz_or_pcsxyz -} do (_270 : {}) <- @MatchBytes "XYZ "
-                                                                  pure {nciexyz_or_pcsxyz: _270}
-                                     | {- cielab_or_pcslab -} do (_271 : {}) <- @MatchBytes "Lab "
-                                                                 pure {cielab_or_pcslab: _271}
-                                     | {- cieluv -} do (_272 : {}) <- @MatchBytes "Luv "
-                                                       pure {cieluv: _272}
-                                     | {- ycbcr -} do (_273 : {}) <- @MatchBytes "Ycbr"
-                                                      pure {ycbcr: _273}
-                                     | {- cieyxy -} do (_274 : {}) <- @MatchBytes "Yxy "
-                                                       pure {cieyxy: _274}
-                                     | {- rgb -} do (_275 : {}) <- @MatchBytes "RGB "
-                                                    pure {rgb: _275}
-                                     | {- gray -} do (_276 : {}) <- @MatchBytes "GRAY"
-                                                     pure {gray: _276}
-                                     | {- hsv -} do (_277 : {}) <- @MatchBytes "HSV "
-                                                    pure {hsv: _277}
-                                     | {- hls -} do (_278 : {}) <- @MatchBytes "HLS "
-                                                    pure {hls: _278}
-                                     | {- cmyk -} do (_279 : {}) <- @MatchBytes "CMYK"
-                                                     pure {cmyk: _279}
-                                     | {- cmy -} do (_280 : {}) <- @MatchBytes "CMY "
-                                                    pure {cmy: _280}
-                                     | {- two_colour -} do (_281 : {}) <- @MatchBytes "2CLR"
-                                                           pure {two_colour: _281}
-                                     | {- three_colour -} do (_282 : {}) <- @MatchBytes "3CLR"
-                                                             pure {three_colour: _282}
-                                     | {- four_colour -} do (_283 : {}) <- @MatchBytes "4CLR"
-                                                            pure {four_colour: _283}
-                                     | {- five_colour -} do (_284 : {}) <- @MatchBytes "5CLR"
-                                                            pure {five_colour: _284}
-                                     | {- six_colour -} do (_285 : {}) <- @MatchBytes "6CLR"
-                                                           pure {six_colour: _285}
-                                     | {- seven_colour -} do (_286 : {}) <- @MatchBytes "7CLR"
-                                                             pure {seven_colour: _286}
-                                     | {- eight_colour -} do (_287 : {}) <- @MatchBytes "8CLR"
-                                                             pure {eight_colour: _287}
-                                     | {- nine_colour -} do (_288 : {}) <- @MatchBytes "9CLR"
-                                                            pure {nine_colour: _288}
-                                     | {- ten_colour -} do (_289 : {}) <- @MatchBytes "ACLR"
-                                                           pure {ten_colour: _289}
-                                     | {- eleven_colour -} do (_290 : {}) <- @MatchBytes "BCLR"
-                                                              pure {eleven_colour: _290}
-                                     | {- twelve_colour -} do (_291 : {}) <- @MatchBytes "CCLR"
-                                                              pure {twelve_colour: _291}
-                                     | {- thirteen_colour -} do (_292 : {}) <- @MatchBytes "DCLR"
-                                                                pure {thirteen_colour: _292}
-                                     | {- fourteen_colour -} do (_293 : {}) <- @MatchBytes "ECLR"
-                                                                pure {fourteen_colour: _293}
-                                     | {- fifteen_colour -} do (_294 : {}) <- @MatchBytes "FCLR"
-                                                               pure {fifteen_colour: _294}
+                                     { {- nciexyz_or_pcsxyz -} do (_246 : {}) <- @MatchBytes "XYZ "
+                                                                  pure {nciexyz_or_pcsxyz: _246}
+                                     | {- cielab_or_pcslab -} do (_247 : {}) <- @MatchBytes "Lab "
+                                                                 pure {cielab_or_pcslab: _247}
+                                     | {- cieluv -} do (_248 : {}) <- @MatchBytes "Luv "
+                                                       pure {cieluv: _248}
+                                     | {- ycbcr -} do (_249 : {}) <- @MatchBytes "Ycbr"
+                                                      pure {ycbcr: _249}
+                                     | {- cieyxy -} do (_250 : {}) <- @MatchBytes "Yxy "
+                                                       pure {cieyxy: _250}
+                                     | {- rgb -} do (_251 : {}) <- @MatchBytes "RGB "
+                                                    pure {rgb: _251}
+                                     | {- gray -} do (_252 : {}) <- @MatchBytes "GRAY"
+                                                     pure {gray: _252}
+                                     | {- hsv -} do (_253 : {}) <- @MatchBytes "HSV "
+                                                    pure {hsv: _253}
+                                     | {- hls -} do (_254 : {}) <- @MatchBytes "HLS "
+                                                    pure {hls: _254}
+                                     | {- cmyk -} do (_255 : {}) <- @MatchBytes "CMYK"
+                                                     pure {cmyk: _255}
+                                     | {- cmy -} do (_256 : {}) <- @MatchBytes "CMY "
+                                                    pure {cmy: _256}
+                                     | {- two_colour -} do (_257 : {}) <- @MatchBytes "2CLR"
+                                                           pure {two_colour: _257}
+                                     | {- three_colour -} do (_258 : {}) <- @MatchBytes "3CLR"
+                                                             pure {three_colour: _258}
+                                     | {- four_colour -} do (_259 : {}) <- @MatchBytes "4CLR"
+                                                            pure {four_colour: _259}
+                                     | {- five_colour -} do (_260 : {}) <- @MatchBytes "5CLR"
+                                                            pure {five_colour: _260}
+                                     | {- six_colour -} do (_261 : {}) <- @MatchBytes "6CLR"
+                                                           pure {six_colour: _261}
+                                     | {- seven_colour -} do (_262 : {}) <- @MatchBytes "7CLR"
+                                                             pure {seven_colour: _262}
+                                     | {- eight_colour -} do (_263 : {}) <- @MatchBytes "8CLR"
+                                                             pure {eight_colour: _263}
+                                     | {- nine_colour -} do (_264 : {}) <- @MatchBytes "9CLR"
+                                                            pure {nine_colour: _264}
+                                     | {- ten_colour -} do (_265 : {}) <- @MatchBytes "ACLR"
+                                                           pure {ten_colour: _265}
+                                     | {- eleven_colour -} do (_266 : {}) <- @MatchBytes "BCLR"
+                                                              pure {eleven_colour: _266}
+                                     | {- twelve_colour -} do (_267 : {}) <- @MatchBytes "CCLR"
+                                                              pure {twelve_colour: _267}
+                                     | {- thirteen_colour -} do (_268 : {}) <- @MatchBytes "DCLR"
+                                                                pure {thirteen_colour: _268}
+                                     | {- fourteen_colour -} do (_269 : {}) <- @MatchBytes "ECLR"
+                                                                pure {fourteen_colour: _269}
+                                     | {- fifteen_colour -} do (_270 : {}) <- @MatchBytes "FCLR"
+                                                               pure {fifteen_colour: _270}
                                      }
      pure $$
  
 ICC.PrimaryPlatforms : Grammar ICC.PrimaryPlatforms =
   do ($$ : ICC.PrimaryPlatforms) <- Choose biased
-                                      { {- none -} do (_296 : {}) <- @MatchBytes [0,
+                                      { {- none -} do (_272 : {}) <- @MatchBytes [0,
                                                                                   0,
                                                                                   0,
                                                                                   0]
-                                                      pure {none: _296}
-                                      | {- apple_computer_inc -} do (_297 : {}) <- @MatchBytes "APPL"
-                                                                    pure {apple_computer_inc: _297}
-                                      | {- microsoft_corporation -} do (_298 : {}) <- @MatchBytes "MSFT"
-                                                                       pure {microsoft_corporation: _298}
-                                      | {- silicon_graphics_inc -} do (_299 : {}) <- @MatchBytes "SGI "
-                                                                      pure {silicon_graphics_inc: _299}
-                                      | {- sun_microsystems -} do (_300 : {}) <- @MatchBytes "SUNW"
-                                                                  pure {sun_microsystems: _300}
+                                                      pure {none: _272}
+                                      | {- apple_computer_inc -} do (_273 : {}) <- @MatchBytes "APPL"
+                                                                    pure {apple_computer_inc: _273}
+                                      | {- microsoft_corporation -} do (_274 : {}) <- @MatchBytes "MSFT"
+                                                                       pure {microsoft_corporation: _274}
+                                      | {- silicon_graphics_inc -} do (_275 : {}) <- @MatchBytes "SGI "
+                                                                      pure {silicon_graphics_inc: _275}
+                                      | {- sun_microsystems -} do (_276 : {}) <- @MatchBytes "SUNW"
+                                                                  pure {sun_microsystems: _276}
                                       }
      pure $$
  
 ICC.RenderingIntent : Grammar ICC.RenderingIntent =
   do ($$ : ICC.RenderingIntent) <- Choose biased
-                                     { {- perceptual -} do (_302 : {}) <- @MatchBytes [0,
+                                     { {- perceptual -} do (_278 : {}) <- @MatchBytes [0,
                                                                                        0,
                                                                                        0,
                                                                                        0]
-                                                           pure {perceptual: _302}
-                                     | {- media_relative_colorimetric -} do (_303 : {}) <- @MatchBytes [0,
+                                                           pure {perceptual: _278}
+                                     | {- media_relative_colorimetric -} do (_279 : {}) <- @MatchBytes [0,
                                                                                                         0,
                                                                                                         0,
                                                                                                         1]
-                                                                            pure {media_relative_colorimetric: _303}
-                                     | {- saturation -} do (_304 : {}) <- @MatchBytes [0,
+                                                                            pure {media_relative_colorimetric: _279}
+                                     | {- saturation -} do (_280 : {}) <- @MatchBytes [0,
                                                                                        0,
                                                                                        0,
                                                                                        2]
-                                                           pure {saturation: _304}
-                                     | {- icc_absolute_colorimetric -} do (_305 : {}) <- @MatchBytes [0,
+                                                           pure {saturation: _280}
+                                     | {- icc_absolute_colorimetric -} do (_281 : {}) <- @MatchBytes [0,
                                                                                                       0,
                                                                                                       0,
                                                                                                       3]
-                                                                          pure {icc_absolute_colorimetric: _305}
+                                                                          pure {icc_absolute_colorimetric: _281}
                                      }
      pure $$
  
 ICC.BE16 : Grammar (uint 16) =
-  do (_306 : uint 8) <- GetByte
-     (_307 : uint 8) <- GetByte
-     pure (_306 # _307)
+  do (_282 : uint 8) <- GetByte
+     (_283 : uint 8) <- GetByte
+     pure (_282 # _283)
  
 ICC.BE32 : Grammar (uint 32) =
-  do (_308 : uint 16) <- ICC.BE16
-     (_309 : uint 16) <- ICC.BE16
-     pure (_308 # _309)
+  do (_284 : uint 16) <- ICC.BE16
+     (_285 : uint 16) <- ICC.BE16
+     pure (_284 # _285)
  
 ICC.XYZNumber : Grammar ICC.XYZNumber =
   do (x : uint 32) <- ICC.BE32
@@ -435,9 +435,9 @@ ICC.DateTimeNumber : Grammar ICC.DateTimeNumber =
            second = second}
  
 ICC.BE64 : Grammar (uint 64) =
-  do (_310 : uint 32) <- ICC.BE32
-     (_311 : uint 32) <- ICC.BE32
-     pure (_310 # _311)
+  do (_286 : uint 32) <- ICC.BE32
+     (_287 : uint 32) <- ICC.BE32
+     pure (_286 # _287)
  
 ICC.ProfileHeader : Grammar ICC.ProfileHeader =
   do (size : uint 32) <- ICC.BE32
@@ -508,8 +508,8 @@ ICC.PositionNumber : Grammar ICC.PositionNumber =
            size = size}
  
 ICC.ASCII7 : Grammar [uint 7] =
-  do ($$ : [uint 7]) <- Many[] do (_313 : uint 8) <- Match (1 .. 255)
-                                  _313 AS uint 7
+  do ($$ : [uint 7]) <- Many[] do (_289 : uint 8) <- Match (1 .. 255)
+                                  _289 AS uint 7
      Choose biased
        { @Many[ 1 .. ] @Match {'\NUL'}
        | Fail "Non 0 string terminator"
@@ -646,34 +646,34 @@ ICC.LutBToAType : Grammar ICC.LutBToAType =
  
 ICC.Lut_8_16_AB_BA : Grammar ICC.Lut_8_16_AB_BA =
   Choose biased
-    { {- lut8 -} do (_319 : ICC.Lut8Type) <- ICC.Lut8Type
-                    pure {lut8: _319}
-    | {- lut16 -} do (_320 : ICC.Lut16Type) <- ICC.Lut16Type
-                     pure {lut16: _320}
-    | {- lutAB -} do (_321 : ICC.LutAToBType) <- ICC.LutAToBType
-                     pure {lutAB: _321}
-    | {- lutBA -} do (_322 : ICC.LutBToAType) <- ICC.LutBToAType
-                     pure {lutBA: _322}
+    { {- lut8 -} do (_295 : ICC.Lut8Type) <- ICC.Lut8Type
+                    pure {lut8: _295}
+    | {- lut16 -} do (_296 : ICC.Lut16Type) <- ICC.Lut16Type
+                     pure {lut16: _296}
+    | {- lutAB -} do (_297 : ICC.LutAToBType) <- ICC.LutAToBType
+                     pure {lutAB: _297}
+    | {- lutBA -} do (_298 : ICC.LutBToAType) <- ICC.LutBToAType
+                     pure {lutBA: _298}
     }
  
 ICC.Lut_8_16_AB : Grammar ICC.Lut_8_16_AB =
   Choose biased
-    { {- lut8 -} do (_323 : ICC.Lut8Type) <- ICC.Lut8Type
-                    pure {lut8: _323}
-    | {- lut16 -} do (_324 : ICC.Lut16Type) <- ICC.Lut16Type
-                     pure {lut16: _324}
-    | {- lutAB -} do (_325 : ICC.LutAToBType) <- ICC.LutAToBType
-                     pure {lutAB: _325}
+    { {- lut8 -} do (_299 : ICC.Lut8Type) <- ICC.Lut8Type
+                    pure {lut8: _299}
+    | {- lut16 -} do (_300 : ICC.Lut16Type) <- ICC.Lut16Type
+                     pure {lut16: _300}
+    | {- lutAB -} do (_301 : ICC.LutAToBType) <- ICC.LutAToBType
+                     pure {lutAB: _301}
     }
  
 ICC.Lut_8_16_BA : Grammar ICC.Lut_8_16_BA =
   Choose biased
-    { {- lut8 -} do (_326 : ICC.Lut8Type) <- ICC.Lut8Type
-                    pure {lut8: _326}
-    | {- lut16 -} do (_327 : ICC.Lut16Type) <- ICC.Lut16Type
-                     pure {lut16: _327}
-    | {- lutBA -} do (_328 : ICC.LutBToAType) <- ICC.LutBToAType
-                     pure {lutBA: _328}
+    { {- lut8 -} do (_302 : ICC.Lut8Type) <- ICC.Lut8Type
+                    pure {lut8: _302}
+    | {- lut16 -} do (_303 : ICC.Lut16Type) <- ICC.Lut16Type
+                     pure {lut16: _303}
+    | {- lutBA -} do (_304 : ICC.LutBToAType) <- ICC.LutBToAType
+                     pure {lutBA: _304}
     }
  
 ICC.CurveType : Grammar [uint 16] =
@@ -693,10 +693,10 @@ ICC.ParametricCurveType : Grammar ICC.ParametricCurveType =
  
 ICC.SomeCurve : Grammar ICC.SomeCurve =
   Choose biased
-    { {- curve -} do (_330 : [uint 16]) <- ICC.CurveType
-                     pure {curve: _330}
-    | {- parametric_curve -} do (_331 : ICC.ParametricCurveType) <- ICC.ParametricCurveType
-                                pure {parametric_curve: _331}
+    { {- curve -} do (_306 : [uint 16]) <- ICC.CurveType
+                     pure {curve: _306}
+    | {- parametric_curve -} do (_307 : ICC.ParametricCurveType) <- ICC.ParametricCurveType
+                                pure {parametric_curve: _307}
     }
  
 ICC.DateTimeType : Grammar ICC.DateTimeNumber =
@@ -895,246 +895,246 @@ ICC.ViewConditionsType : Grammar ICC.ViewConditionsType =
 ICC.Tag (sig : [uint 8]) : Grammar ICC.Tag =
   Choose biased
     { Choose biased
-        { {- AToB0 -} do (_345 : ICC.Lut_8_16_AB) <- do ICC._Guard (sig == "A2B0")
+        { {- AToB0 -} do (_321 : ICC.Lut_8_16_AB) <- do ICC._Guard (sig == "A2B0")
                                                         Commit
                                                           do ($$ : ICC.Lut_8_16_AB) <- ICC.Lut_8_16_AB
                                                              pure $$
-                         pure {AToB0: _345}
-        | {- AToB1 -} do (_347 : ICC.Lut_8_16_AB) <- do ICC._Guard (sig == "A2B1")
+                         pure {AToB0: _321}
+        | {- AToB1 -} do (_323 : ICC.Lut_8_16_AB) <- do ICC._Guard (sig == "A2B1")
                                                         Commit
                                                           do ($$ : ICC.Lut_8_16_AB) <- ICC.Lut_8_16_AB
                                                              pure $$
-                         pure {AToB1: _347}
-        | {- AToB2 -} do (_349 : ICC.Lut_8_16_AB) <- do ICC._Guard (sig == "A2B2")
+                         pure {AToB1: _323}
+        | {- AToB2 -} do (_325 : ICC.Lut_8_16_AB) <- do ICC._Guard (sig == "A2B2")
                                                         Commit
                                                           do ($$ : ICC.Lut_8_16_AB) <- ICC.Lut_8_16_AB
                                                              pure $$
-                         pure {AToB2: _349}
-        | {- blueMatrixColumn -} do (_351 : [ICC.XYZNumber]) <- do ICC._Guard (sig == "bXYZ")
+                         pure {AToB2: _325}
+        | {- blueMatrixColumn -} do (_327 : [ICC.XYZNumber]) <- do ICC._Guard (sig == "bXYZ")
                                                                    Commit
                                                                      do ($$ : [ICC.XYZNumber]) <- ICC.XYZType
                                                                         pure $$
-                                    pure {blueMatrixColumn: _351}
-        | {- blueTRC -} do (_353 : ICC.SomeCurve) <- do ICC._Guard (sig == "bTRC")
+                                    pure {blueMatrixColumn: _327}
+        | {- blueTRC -} do (_329 : ICC.SomeCurve) <- do ICC._Guard (sig == "bTRC")
                                                         Commit
                                                           do ($$ : ICC.SomeCurve) <- ICC.SomeCurve
                                                              pure $$
-                           pure {blueTRC: _353}
-        | {- BToA0 -} do (_355 : ICC.Lut_8_16_BA) <- do ICC._Guard (sig == "B2A0")
+                           pure {blueTRC: _329}
+        | {- BToA0 -} do (_331 : ICC.Lut_8_16_BA) <- do ICC._Guard (sig == "B2A0")
                                                         Commit
                                                           do ($$ : ICC.Lut_8_16_BA) <- ICC.Lut_8_16_BA
                                                              pure $$
-                         pure {BToA0: _355}
-        | {- BToA1 -} do (_357 : ICC.Lut_8_16_BA) <- do ICC._Guard (sig == "B2A1")
+                         pure {BToA0: _331}
+        | {- BToA1 -} do (_333 : ICC.Lut_8_16_BA) <- do ICC._Guard (sig == "B2A1")
                                                         Commit
                                                           do ($$ : ICC.Lut_8_16_BA) <- ICC.Lut_8_16_BA
                                                              pure $$
-                         pure {BToA1: _357}
-        | {- BToA2 -} do (_359 : ICC.Lut_8_16_BA) <- do ICC._Guard (sig == "B2A2")
+                         pure {BToA1: _333}
+        | {- BToA2 -} do (_335 : ICC.Lut_8_16_BA) <- do ICC._Guard (sig == "B2A2")
                                                         Commit
                                                           do ($$ : ICC.Lut_8_16_BA) <- ICC.Lut_8_16_BA
                                                              pure $$
-                         pure {BToA2: _359}
-        | {- BToD0 -} do (_361 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "B2D0")
+                         pure {BToA2: _335}
+        | {- BToD0 -} do (_337 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "B2D0")
                                                                      Commit
                                                                        do ($$ : ICC.MultiProcessElementsType) <- ICC.MultiProcessElementsType
                                                                           pure $$
-                         pure {BToD0: _361}
-        | {- BToD1 -} do (_363 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "B2D1")
+                         pure {BToD0: _337}
+        | {- BToD1 -} do (_339 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "B2D1")
                                                                      Commit
                                                                        do ($$ : ICC.MultiProcessElementsType) <- ICC.MultiProcessElementsType
                                                                           pure $$
-                         pure {BToD1: _363}
-        | {- BToD2 -} do (_365 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "B2D2")
+                         pure {BToD1: _339}
+        | {- BToD2 -} do (_341 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "B2D2")
                                                                      Commit
                                                                        do ($$ : ICC.MultiProcessElementsType) <- ICC.MultiProcessElementsType
                                                                           pure $$
-                         pure {BToD2: _365}
-        | {- BToD3 -} do (_367 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "B2D3")
+                         pure {BToD2: _341}
+        | {- BToD3 -} do (_343 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "B2D3")
                                                                      Commit
                                                                        do ($$ : ICC.MultiProcessElementsType) <- ICC.MultiProcessElementsType
                                                                           pure $$
-                         pure {BToD3: _367}
-        | {- calibrationDateTime -} do (_369 : ICC.DateTimeNumber) <- do ICC._Guard (sig == "calt")
+                         pure {BToD3: _343}
+        | {- calibrationDateTime -} do (_345 : ICC.DateTimeNumber) <- do ICC._Guard (sig == "calt")
                                                                          Commit
                                                                            do ($$ : ICC.DateTimeNumber) <- ICC.DateTimeType
                                                                               pure $$
-                                       pure {calibrationDateTime: _369}
-        | {- charTarget -} do (_371 : [uint 7]) <- do ICC._Guard (sig == "targ")
+                                       pure {calibrationDateTime: _345}
+        | {- charTarget -} do (_347 : [uint 7]) <- do ICC._Guard (sig == "targ")
                                                       Commit
                                                         do ($$ : [uint 7]) <- ICC.TextType
                                                            pure $$
-                              pure {charTarget: _371}
-        | {- chromaticAdaptation -} do (_373 : [uint 32]) <- do ICC._Guard (sig == "chad")
+                              pure {charTarget: _347}
+        | {- chromaticAdaptation -} do (_349 : [uint 32]) <- do ICC._Guard (sig == "chad")
                                                                 Commit
                                                                   do ($$ : [uint 32]) <- ICC.S15Fixed16ArrayType
                                                                      pure $$
-                                       pure {chromaticAdaptation: _373}
-        | {- colorantOrder -} do (_375 : [uint 8]) <- do ICC._Guard (sig == "clro")
+                                       pure {chromaticAdaptation: _349}
+        | {- colorantOrder -} do (_351 : [uint 8]) <- do ICC._Guard (sig == "clro")
                                                          Commit
                                                            do ($$ : [uint 8]) <- ICC.ColorantOrderType
                                                               pure $$
-                                 pure {colorantOrder: _375}
-        | {- colorantTable -} do (_377 : [ICC.Colorant]) <- do ICC._Guard (sig == "clrt")
+                                 pure {colorantOrder: _351}
+        | {- colorantTable -} do (_353 : [ICC.Colorant]) <- do ICC._Guard (sig == "clrt")
                                                                Commit
                                                                  do ($$ : [ICC.Colorant]) <- ICC.ColorantTableType
                                                                     pure $$
-                                 pure {colorantTable: _377}
-        | {- colorantTableOut -} do (_379 : [ICC.Colorant]) <- do ICC._Guard (sig == "clot")
+                                 pure {colorantTable: _353}
+        | {- colorantTableOut -} do (_355 : [ICC.Colorant]) <- do ICC._Guard (sig == "clot")
                                                                   Commit
                                                                     do ($$ : [ICC.Colorant]) <- ICC.ColorantTableType
                                                                        pure $$
-                                    pure {colorantTableOut: _379}
-        | {- colorimetricIntentImageState -} do (_381 : [uint 8]) <- do ICC._Guard (sig == "ciis")
+                                    pure {colorantTableOut: _355}
+        | {- colorimetricIntentImageState -} do (_357 : [uint 8]) <- do ICC._Guard (sig == "ciis")
                                                                         Commit
                                                                           do ($$ : [uint 8]) <- ICC.SignatureType
                                                                              pure $$
-                                                pure {colorimetricIntentImageState: _381}
-        | {- copyright -} do (_383 : [ICC.UnicodeRecord]) <- do ICC._Guard (sig == "cprt")
+                                                pure {colorimetricIntentImageState: _357}
+        | {- copyright -} do (_359 : [ICC.UnicodeRecord]) <- do ICC._Guard (sig == "cprt")
                                                                 Commit
                                                                   do ($$ : [ICC.UnicodeRecord]) <- ICC.MultiLocalizedUnicodeType
                                                                      pure $$
-                             pure {copyright: _383}
-        | {- deviceMfgDesc -} do (_385 : [ICC.UnicodeRecord]) <- do ICC._Guard (sig == "dmnd")
+                             pure {copyright: _359}
+        | {- deviceMfgDesc -} do (_361 : [ICC.UnicodeRecord]) <- do ICC._Guard (sig == "dmnd")
                                                                     Commit
                                                                       do ($$ : [ICC.UnicodeRecord]) <- ICC.MultiLocalizedUnicodeType
                                                                          pure $$
-                                 pure {deviceMfgDesc: _385}
-        | {- deviceModelDesc -} do (_387 : [ICC.UnicodeRecord]) <- do ICC._Guard (sig == "dmdd")
+                                 pure {deviceMfgDesc: _361}
+        | {- deviceModelDesc -} do (_363 : [ICC.UnicodeRecord]) <- do ICC._Guard (sig == "dmdd")
                                                                       Commit
                                                                         do ($$ : [ICC.UnicodeRecord]) <- ICC.MultiLocalizedUnicodeType
                                                                            pure $$
-                                   pure {deviceModelDesc: _387}
-        | {- DToB0 -} do (_389 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "D2B0")
+                                   pure {deviceModelDesc: _363}
+        | {- DToB0 -} do (_365 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "D2B0")
                                                                      Commit
                                                                        do ($$ : ICC.MultiProcessElementsType) <- ICC.MultiProcessElementsType
                                                                           pure $$
-                         pure {DToB0: _389}
-        | {- DToB1 -} do (_391 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "D2B1")
+                         pure {DToB0: _365}
+        | {- DToB1 -} do (_367 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "D2B1")
                                                                      Commit
                                                                        do ($$ : ICC.MultiProcessElementsType) <- ICC.MultiProcessElementsType
                                                                           pure $$
-                         pure {DToB1: _391}
-        | {- DToB2 -} do (_393 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "D2B2")
+                         pure {DToB1: _367}
+        | {- DToB2 -} do (_369 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "D2B2")
                                                                      Commit
                                                                        do ($$ : ICC.MultiProcessElementsType) <- ICC.MultiProcessElementsType
                                                                           pure $$
-                         pure {DToB2: _393}
-        | {- DToB3 -} do (_395 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "D2B3")
+                         pure {DToB2: _369}
+        | {- DToB3 -} do (_371 : ICC.MultiProcessElementsType) <- do ICC._Guard (sig == "D2B3")
                                                                      Commit
                                                                        do ($$ : ICC.MultiProcessElementsType) <- ICC.MultiProcessElementsType
                                                                           pure $$
-                         pure {DToB3: _395}
-        | {- gamut -} do (_397 : ICC.Lut_8_16_BA) <- do ICC._Guard (sig == "gamt")
+                         pure {DToB3: _371}
+        | {- gamut -} do (_373 : ICC.Lut_8_16_BA) <- do ICC._Guard (sig == "gamt")
                                                         Commit
                                                           do ($$ : ICC.Lut_8_16_BA) <- ICC.Lut_8_16_BA
                                                              pure $$
-                         pure {gamut: _397}
-        | {- grayTRC -} do (_399 : ICC.SomeCurve) <- do ICC._Guard (sig == "kTRC")
+                         pure {gamut: _373}
+        | {- grayTRC -} do (_375 : ICC.SomeCurve) <- do ICC._Guard (sig == "kTRC")
                                                         Commit
                                                           do ($$ : ICC.SomeCurve) <- ICC.SomeCurve
                                                              pure $$
-                           pure {grayTRC: _399}
-        | {- greenMatrixColumn -} do (_401 : [ICC.XYZNumber]) <- do ICC._Guard (sig == "gXYZ")
+                           pure {grayTRC: _375}
+        | {- greenMatrixColumn -} do (_377 : [ICC.XYZNumber]) <- do ICC._Guard (sig == "gXYZ")
                                                                     Commit
                                                                       do ($$ : [ICC.XYZNumber]) <- ICC.XYZType
                                                                          pure $$
-                                     pure {greenMatrixColumn: _401}
-        | {- greenTRC -} do (_403 : ICC.SomeCurve) <- do ICC._Guard (sig == "gTRC")
+                                     pure {greenMatrixColumn: _377}
+        | {- greenTRC -} do (_379 : ICC.SomeCurve) <- do ICC._Guard (sig == "gTRC")
                                                          Commit
                                                            do ($$ : ICC.SomeCurve) <- ICC.SomeCurve
                                                               pure $$
-                            pure {greenTRC: _403}
-        | {- luminance -} do (_405 : [ICC.XYZNumber]) <- do ICC._Guard (sig == "lumi")
+                            pure {greenTRC: _379}
+        | {- luminance -} do (_381 : [ICC.XYZNumber]) <- do ICC._Guard (sig == "lumi")
                                                             Commit
                                                               do ($$ : [ICC.XYZNumber]) <- ICC.XYZType
                                                                  pure $$
-                             pure {luminance: _405}
-        | {- measurement -} do (_407 : ICC.MeasurementType) <- do ICC._Guard (sig == "meas")
+                             pure {luminance: _381}
+        | {- measurement -} do (_383 : ICC.MeasurementType) <- do ICC._Guard (sig == "meas")
                                                                   Commit
                                                                     do ($$ : ICC.MeasurementType) <- ICC.MeasurementType
                                                                        pure $$
-                               pure {measurement: _407}
-        | {- mediaWhitePoint -} do (_409 : [ICC.XYZNumber]) <- do ICC._Guard (sig == "wtpt")
+                               pure {measurement: _383}
+        | {- mediaWhitePoint -} do (_385 : [ICC.XYZNumber]) <- do ICC._Guard (sig == "wtpt")
                                                                   Commit
                                                                     do ($$ : [ICC.XYZNumber]) <- ICC.XYZType
                                                                        pure $$
-                                   pure {mediaWhitePoint: _409}
-        | {- namedColor2 -} do (_411 : ICC.NamedColor2Type) <- do ICC._Guard (sig == "ncl2")
+                                   pure {mediaWhitePoint: _385}
+        | {- namedColor2 -} do (_387 : ICC.NamedColor2Type) <- do ICC._Guard (sig == "ncl2")
                                                                   Commit
                                                                     do ($$ : ICC.NamedColor2Type) <- ICC.NamedColor2Type
                                                                        pure $$
-                               pure {namedColor2: _411}
-        | {- outputResponse -} do (_413 : [ICC.ResponseCurve]) <- do ICC._Guard (sig == "resp")
+                               pure {namedColor2: _387}
+        | {- outputResponse -} do (_389 : [ICC.ResponseCurve]) <- do ICC._Guard (sig == "resp")
                                                                      Commit
                                                                        do ($$ : [ICC.ResponseCurve]) <- ICC.ResponseCurveSet16Type
                                                                           pure $$
-                                  pure {outputResponse: _413}
-        | {- perceptualRenderingIntentGamut -} do (_415 : [uint 8]) <- do ICC._Guard (sig == "rig0")
+                                  pure {outputResponse: _389}
+        | {- perceptualRenderingIntentGamut -} do (_391 : [uint 8]) <- do ICC._Guard (sig == "rig0")
                                                                           Commit
                                                                             do ($$ : [uint 8]) <- ICC.SignatureType
                                                                                pure $$
-                                                  pure {perceptualRenderingIntentGamut: _415}
-        | {- preview0 -} do (_417 : ICC.Lut_8_16_AB_BA) <- do ICC._Guard (sig == "pre0")
+                                                  pure {perceptualRenderingIntentGamut: _391}
+        | {- preview0 -} do (_393 : ICC.Lut_8_16_AB_BA) <- do ICC._Guard (sig == "pre0")
                                                               Commit
                                                                 do ($$ : ICC.Lut_8_16_AB_BA) <- ICC.Lut_8_16_AB_BA
                                                                    pure $$
-                            pure {preview0: _417}
-        | {- preview1 -} do (_419 : ICC.Lut_8_16_BA) <- do ICC._Guard (sig == "pre1")
+                            pure {preview0: _393}
+        | {- preview1 -} do (_395 : ICC.Lut_8_16_BA) <- do ICC._Guard (sig == "pre1")
                                                            Commit
                                                              do ($$ : ICC.Lut_8_16_BA) <- ICC.Lut_8_16_BA
                                                                 pure $$
-                            pure {preview1: _419}
-        | {- preview2 -} do (_421 : ICC.Lut_8_16_BA) <- do ICC._Guard (sig == "pre2")
+                            pure {preview1: _395}
+        | {- preview2 -} do (_397 : ICC.Lut_8_16_BA) <- do ICC._Guard (sig == "pre2")
                                                            Commit
                                                              do ($$ : ICC.Lut_8_16_BA) <- ICC.Lut_8_16_BA
                                                                 pure $$
-                            pure {preview2: _421}
-        | {- profileDescription -} do (_423 : [ICC.UnicodeRecord]) <- do ICC._Guard (sig == "desc")
+                            pure {preview2: _397}
+        | {- profileDescription -} do (_399 : [ICC.UnicodeRecord]) <- do ICC._Guard (sig == "desc")
                                                                          Commit
                                                                            do ($$ : [ICC.UnicodeRecord]) <- ICC.MultiLocalizedUnicodeType
                                                                               pure $$
-                                      pure {profileDescription: _423}
-        | {- profileSequenceDesc -} do (_425 : [uint 8]) <- do ICC._Guard (sig == "pseq")
+                                      pure {profileDescription: _399}
+        | {- profileSequenceDesc -} do (_401 : [uint 8]) <- do ICC._Guard (sig == "pseq")
                                                                Commit
                                                                  do ($$ : [uint 8]) <- ICC.ProfileSequenceDescType
                                                                     pure $$
-                                       pure {profileSequenceDesc: _425}
-        | {- profileSequenceIdentifier -} do (_427 : {}) <- do ICC._Guard (sig == "psid")
+                                       pure {profileSequenceDesc: _401}
+        | {- profileSequenceIdentifier -} do (_403 : {}) <- do ICC._Guard (sig == "psid")
                                                                Commit
                                                                  do ($$ : {}) <- pure {}
                                                                     pure $$
-                                             pure {profileSequenceIdentifier: _427}
-        | {- redMatrixColumn -} do (_429 : [ICC.XYZNumber]) <- do ICC._Guard (sig == "rXYZ")
+                                             pure {profileSequenceIdentifier: _403}
+        | {- redMatrixColumn -} do (_405 : [ICC.XYZNumber]) <- do ICC._Guard (sig == "rXYZ")
                                                                   Commit
                                                                     do ($$ : [ICC.XYZNumber]) <- ICC.XYZType
                                                                        pure $$
-                                   pure {redMatrixColumn: _429}
-        | {- redTRC -} do (_431 : ICC.SomeCurve) <- do ICC._Guard (sig == "rTRC")
+                                   pure {redMatrixColumn: _405}
+        | {- redTRC -} do (_407 : ICC.SomeCurve) <- do ICC._Guard (sig == "rTRC")
                                                        Commit
                                                          do ($$ : ICC.SomeCurve) <- ICC.SomeCurve
                                                             pure $$
-                          pure {redTRC: _431}
-        | {- saturationRenderingIntentGamut -} do (_433 : [uint 8]) <- do ICC._Guard (sig == "rig2")
+                          pure {redTRC: _407}
+        | {- saturationRenderingIntentGamut -} do (_409 : [uint 8]) <- do ICC._Guard (sig == "rig2")
                                                                           Commit
                                                                             do ($$ : [uint 8]) <- ICC.SignatureType
                                                                                pure $$
-                                                  pure {saturationRenderingIntentGamut: _433}
-        | {- technology -} do (_435 : [uint 8]) <- do ICC._Guard (sig == "tech")
+                                                  pure {saturationRenderingIntentGamut: _409}
+        | {- technology -} do (_411 : [uint 8]) <- do ICC._Guard (sig == "tech")
                                                       Commit
                                                         do ($$ : [uint 8]) <- ICC.SignatureType
                                                            pure $$
-                              pure {technology: _435}
-        | {- viewCondDesc -} do (_437 : [ICC.UnicodeRecord]) <- do ICC._Guard (sig == "vued")
+                              pure {technology: _411}
+        | {- viewCondDesc -} do (_413 : [ICC.UnicodeRecord]) <- do ICC._Guard (sig == "vued")
                                                                    Commit
                                                                      do ($$ : [ICC.UnicodeRecord]) <- ICC.MultiLocalizedUnicodeType
                                                                         pure $$
-                                pure {viewCondDesc: _437}
-        | {- viewConditions -} do (_439 : ICC.ViewConditionsType) <- do ICC._Guard (sig == "view")
+                                pure {viewCondDesc: _413}
+        | {- viewConditions -} do (_415 : ICC.ViewConditionsType) <- do ICC._Guard (sig == "view")
                                                                         Commit
                                                                           do ($$ : ICC.ViewConditionsType) <- ICC.ViewConditionsType
                                                                              pure $$
-                                  pure {viewConditions: _439}
+                                  pure {viewConditions: _415}
         }
     | Fail (concat ["Unregonized tag: ",
                     sig])
@@ -1315,8 +1315,8 @@ ICC._PositionNumber : Grammar {} =
      ICC._BE32
  
 ICC._ASCII7 : Grammar {} =
-  do @Many[] do (_313 : uint 8) <- Match (1 .. 255)
-                @(_313 AS uint 7)
+  do @Many[] do (_289 : uint 8) <- Match (1 .. 255)
+                @(_289 AS uint 7)
      Choose biased
        { @Many[ 1 .. ] @Match {'\NUL'}
        | Fail "Non 0 string terminator"

--- a/tests/parser-gen/P033.ddl
+++ b/tests/parser-gen/P033.ddl
@@ -2,7 +2,7 @@
 
 def $digit = '0'..'9'
 
-def f (x : int) = x as uint8
+def f (x : int) = x
 
 def A = { @bef = Match1 '<'; a = Many $digit; @after = Match1 '>' }
 

--- a/tests/parser-gen/P033.ddl.stdout
+++ b/tests/parser-gen/P033.ddl.stdout
@@ -19,7 +19,7 @@ P033.$digit : ByteClass =
   '0' .. '9'
  
 P033.f (x : int) : int =
-  x as int
+  x
  
 P033.A : Grammar P033.A =
   do @Match {'<'}


### PR DESCRIPTION
This avoids the pitfalls of the current design, namely:
  * Mistyping a type will now be an error, instead of silently being treated as a variable
  * A type appearing in scope will not silently turn a variable into a type