### PR TITLE
vscode: add information for packaging extension

### DIFF
--- a/syntax-highlight/vscode-daedalus/package.json
+++ b/syntax-highlight/vscode-daedalus/package.json
@@ -2,9 +2,13 @@
     "name": "daedalus",
     "displayName": "daedalus",
     "description": "Language support for Daedalus",
+    "publisher": "galois",
+    "repository": {
+        "url": "https://github.com/GaloisInc/daedalus/tree/master/syntax-highlight/vscode-daedalus"
+    },
     "version": "0.0.1",
     "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.58.1"
     },
     "categories": [
         "Programming Languages"
@@ -24,40 +28,51 @@
                 }
             }
         },
-        "languages": [{
-            "id": "daedalus",
-            "aliases": ["Daedalus", "daedalus"],
-            "extensions": [".ddl"],
-            "configuration": "./language-configuration.json"
-        }],
-        "grammars": [{
-            "language": "daedalus",
-            "scopeName": "source.daedalus",
-            "path": "./syntaxes/daedalus.tmLanguage.json"
-        }]
+        "languages": [
+            {
+                "id": "daedalus",
+                "aliases": [
+                    "Daedalus",
+                    "daedalus"
+                ],
+                "extensions": [
+                    ".ddl"
+                ],
+                "configuration": "./language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "daedalus",
+                "scopeName": "source.daedalus",
+                "path": "./syntaxes/daedalus.tmLanguage.json"
+            }
+        ]
     },
     "dependencies": {
         "vscode-languageclient": "^7.0.0"
     },
     "scripts": {
-        "vscode:prepublish": "npm run compile",
         "compile": "tsc -p ./",
-        "watch": "tsc -watch -p ./",
-        "pretest": "npm run compile && npm run lint",
         "lint": "eslint src --ext ts",
-        "test": "node ./out/test/runTest.js"
+        "package": "vsce package",
+        "pretest": "npm run compile && npm run lint",
+        "test": "node ./out/test/runTest.js",
+        "vscode:prepublish": "npm run compile",
+        "watch": "tsc -watch -p ./"
     },
     "devDependencies": {
-        "@types/vscode": "^1.57.0",
-        "@types/glob": "^7.1.3",
-        "@types/mocha": "^8.2.2",
-        "@types/node": "14.x",
-        "eslint": "^7.27.0",
-        "@typescript-eslint/eslint-plugin": "^4.26.0",
-        "@typescript-eslint/parser": "^4.26.0",
+        "@types/glob": "^7.1.4",
+        "@types/mocha": "^9.0.0",
+        "@types/node": "16.x",
+        "@types/vscode": "^1.58.1",
+        "@typescript-eslint/eslint-plugin": "^4.29.0",
+        "@typescript-eslint/parser": "^4.29.0",
+        "eslint": "^7.32.0",
         "glob": "^7.1.7",
-        "mocha": "^8.4.0",
-        "typescript": "^4.3.2",
-        "vscode-test": "^1.5.2"
+        "mocha": "^9.0.3",
+        "npm-check-updates": "^11.8.3",
+        "typescript": "^4.3.5",
+        "vscode-test": "^1.6.1"
     }
 }


### PR DESCRIPTION
This lets one package extensions via the `npm run package` command.

It will create a VSIX file that can be sent to people, installed via the extensions menu (or via the command palette `Install extension (VSIX)`), to install the extension.

It could also be published to the VSCode extension repository, but we'd want to check with IT.