### PR TITLE
vscode: add support for 'run/watch' and 'run/cancel'

### DIFF
--- a/syntax-highlight/vscode-daedalus/package.json
+++ b/syntax-highlight/vscode-daedalus/package.json
@@ -18,6 +18,10 @@
     ],
     "main": "./out/extension.js",
     "contributes": {
+        "commands": {
+            "command": "daedalus.watch",
+            "title": "Watch at point (DAEDALUS)"
+        },
         "configuration": {
             "title": "Daedalus configuration",
             "properties": {

--- a/syntax-highlight/vscode-daedalus/src/extension.ts
+++ b/syntax-highlight/vscode-daedalus/src/extension.ts
@@ -3,24 +3,29 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as path from 'path';
-import { workspace, ExtensionContext } from 'vscode';
+import * as path from 'path'
+import * as vscode from 'vscode'
+import * as vscodelc from 'vscode-languageclient'
 
 import {
+	ExecuteCommandParams,
+	ExecuteCommandRequest,
 	LanguageClient,
 	LanguageClientOptions,
 	ServerOptions,
 	TransportKind
-} from 'vscode-languageclient/node';
+} from 'vscode-languageclient/node'
 
 import {
 	configLanguageServerPath,
 	getConfiguration,
 } from './configuration'
 
-let client: LanguageClient;
 
-export function activate(context: ExtensionContext) {
+let client: LanguageClient
+
+
+export function activate(context: vscode.ExtensionContext) {
 
 	const configuration = getConfiguration()
 
@@ -32,12 +37,12 @@ export function activate(context: ExtensionContext) {
 	let serverOptions: ServerOptions = {
 		run: { command: serverExecutable, transport: TransportKind.stdio },
 		debug: { command: serverExecutable, transport: TransportKind.stdio }
-	};
+	}
 
 	// Options to control the language client
 	let clientOptions: LanguageClientOptions = {
 		documentSelector: [{ scheme: 'file', language: 'daedalus' }]
-	};
+	}
 
 	// Create the language client and start the client.
 	client = new LanguageClient(
@@ -45,15 +50,140 @@ export function activate(context: ExtensionContext) {
 		'DDL Language Server',
 		serverOptions,
 		clientOptions
-	);
+	)
 
 	// Start the client. This will also launch the server
-	client.start();
+	client.start()
+
+	context.subscriptions.push(
+		vscode.commands.registerTextEditorCommand(
+			'daedalus.watch',
+			daedalusWatch,
+		)
+	)
+
 }
+
 
 export function deactivate(): Thenable<void> | undefined {
 	if (!client) {
-		return undefined;
+		return undefined
 	}
-	return client.stop();
+	return client.stop()
+}
+
+
+function daedalusWatch(editor: vscode.TextEditor): void {
+	vscode.window.withProgress(
+		{
+			cancellable: true,
+			location: vscode.ProgressLocation.Window,
+			title: "Watch at point (DAEDALUS)",
+		},
+		(_progress, vscodeCancellationToken) => {
+			return daedalusWatchProgress(editor, vscodeCancellationToken)
+		},
+	)
+}
+
+
+/**
+ * Sends the 'workspace/executeCommand' request 'run/watch' to the language
+ * server.
+ * @param editor - Editor to watch.
+ * @param callback - Called with the cancellation token received from the
+ * language server, when the request has been acknowledged.
+ */
+function daedalusRunWatch(
+	editor: vscode.TextEditor,
+	callback: (lspCancellationToken: number) => void,
+) {
+
+	const c2p = client.code2ProtocolConverter
+
+	const params: ExecuteCommandParams = {
+		command: 'run/watch',
+		arguments: [
+			c2p.asTextDocumentIdentifier(editor.document),
+			c2p.asPosition(editor.selection.active),
+			c2p.asUri(editor.document.uri),
+		],
+	}
+
+	client
+		.sendRequest(
+			ExecuteCommandRequest.type,
+			params,
+		)
+		.then(callback)
+
+}
+
+
+/**
+ * Sends the 'workspace/executeCommand' request 'run/cancel' to the language
+ * server.
+ * @param lspCancellationToken - Token received from an acknowledged 'run/watch'
+ * command.
+ * @param callback - Called after the request to cancel has been acknowledged.
+ */
+function daedalusRunCancel(
+	lspCancellationToken: number,
+	callback: () => void,
+): void {
+	const cancelParams: ExecuteCommandParams = {
+		command: 'run/cancel',
+		arguments: [
+			lspCancellationToken,
+		],
+	}
+
+	client.sendRequest(
+		ExecuteCommandRequest.type,
+		cancelParams,
+	).then(callback)
+}
+
+
+/**
+ * Sends a watch request to the language server, and awaits either the
+ * 'daedalus/run/watchResult' notification, or an intent from the user to cancel
+ * the request.
+ * @param editor - Editor to watch.
+ * @param vscodeCancellationToken - VSCode token that will indicate if the user
+ * tries to cancel the task.
+ * @returns - Promise resolved upon completion or cancellation.
+ */
+function daedalusWatchProgress(
+	editor: vscode.TextEditor,
+	vscodeCancellationToken: vscode.CancellationToken,
+): Promise<void> {
+
+	return new Promise(resolve => {
+
+		const cleanup = () => {
+			disposable.dispose()
+			resolve()
+		}
+
+		// Listen to watchResult while the request is flying and not cancelled.
+		const disposable = client.onNotification(
+			'daedalus/run/watchResult',
+			({ clientHandle, result }) => {
+				vscode.window.showInformationMessage(result)
+				cleanup()
+			}
+		)
+
+		daedalusRunWatch(
+			editor,
+			lspCancellationToken => {
+				vscodeCancellationToken.onCancellationRequested(() => {
+					daedalusRunCancel(lspCancellationToken, cleanup)
+				})
+			},
+		)
+
+	})
+
 }


### PR DESCRIPTION
This sets up the basic support for the `workspace/executeCommand` commands `run/watch` and `run/cancel`, as well as listening to the `daedalus/run/watchResult` notification as long as some command is in flight.

It is currently set up to show the progress of the request in the status bar (I also hooked up the cancellation to the UI), and to display the result in a pop-up information message.

Of course this is likely not how we want to display this result, but I'm awaiting more information to know where/how it should be presented to the user.

I also have some additional concerns about the semantics of `run/watch`, I'll follow up with @simonjwinwood .