### PR TITLE
Remove ambiguous parses in NITF

### DIFF
--- a/nitf/nitf-modern/nitf_data_ext_subheader.ddl
+++ b/nitf/nitf-modern/nitf_data_ext_subheader.ddl
@@ -23,7 +23,7 @@ def DataExtHeader = {
     nooflw = ^{} ;
   } ;
 
-  dsitem = Choose {
+  dsitem = Choose { -- NOTE-MODERN: nonoverlapping
     present = {
       desoflw is present ;
       UnsignedNum 3

--- a/nitf/nitf-modern/nitf_data_ext_subheader.ddl
+++ b/nitf/nitf-modern/nitf_data_ext_subheader.ddl
@@ -9,6 +9,8 @@ def DataExtHeader = {
 
   common = CommonSubheader ;
 
+  -- NOTE-MODERN: looks like the outer `Choose` should be `Choose1`,
+  -- should double-check that the second branch does not make progress
   desoflw = Choose {
     present = Choose {
       oflwUDHD = @(PadMatch 6 ' ' "UDHD") ;

--- a/nitf/nitf-modern/nitf_data_ext_subheader.ddl
+++ b/nitf/nitf-modern/nitf_data_ext_subheader.ddl
@@ -1,0 +1,33 @@
+import nitf_lib
+
+def DE = Match "DE"
+
+def DataExtHeader = {
+  DE ;
+  desid = Many 25 BCSA ;
+  desver = PosNumber 2 ;
+
+  common = CommonSubheader ;
+
+  desoflw = Choose {
+    present = Choose {
+      oflwUDHD = @(PadMatch 6 ' ' "UDHD") ;
+      oflwUDID = @(PadMatch 6 ' ' "UDID") ;
+      oflwXHD = @(PadMatch 6 ' ' "XHD") ;
+      oflwIXSHD = @(PadMatch 6 ' ' "IXSHD") ;
+      oflwSXSHD = @(PadMatch 6 ' ' "SXSHD") ;
+      oflwTXSHD = @(PadMatch 6 ' ' "TXSHD") ;
+    } ;
+    nooflw = ^{} ;
+  } ;
+
+  dsitem = Choose {
+    present = {
+      desoflw is present ;
+      UnsignedNum 3
+    } ;
+    omitted = desoflw is nooflw ;
+  } ;
+
+  desshl = IsNum 4 0 ;
+}

--- a/nitf/nitf-modern/nitf_graphic_subheader.ddl
+++ b/nitf/nitf-modern/nitf_graphic_subheader.ddl
@@ -39,18 +39,18 @@ def GraphicHeader = {
   sres2 = UnsignedNum 2 ;
 
   -- TODO: refactor this into other subheaders
-  sxshdl = Choose {
+  sxshdl = Choose { -- NOTE-MODERN: This seems to overlap!!!
     notre = @(IsNum 5 0) ;
     taggedrec = BoundedNum 5 3 9741
   } ;
 
-  xssofl = Choose {
+  xssofl = Choose { -- NOTE-MODERN: This seems to overlap!!!
     nooverflow = IsNum 3 0 ;
     desseq = PosNumber 3 ;
     omitted = sxshdl is notre ;
   } ;
 
-  sxshd = Choose {
+  sxshd = Choose { -- NOTE-MODERN: This seems to overlap!!!
     tre = {
       seq = sxshdl is taggedrec ;
       Many (seq as! uint 64) Byte

--- a/nitf/nitf-modern/nitf_graphic_subheader.ddl
+++ b/nitf/nitf-modern/nitf_graphic_subheader.ddl
@@ -1,0 +1,60 @@
+import nitf_lib
+
+def SY = Match "SY"
+
+def SFmt = Match1 'C'
+
+def GraphicColor = Choose {
+  color = Match1 'C' ;
+  mono = Match1 'M'
+}
+
+def GraphicHeader = {
+  SY ;
+  sid = Many 10 BCSA ;
+  sname = Many 20 ECSA ;
+
+  common = CommonSubheader ;
+
+  Encryp ;
+
+  SFmt ;
+
+  sstruct = UnsignedNum 13 ;
+
+  -- TODO: this defines a global property to check
+  sdlvl = UnsignedNum 3 ;
+
+  salvl = AttachmentLvl ;
+
+  sloc = Location ;
+
+  sbnd1 = Location ;
+
+  scolor = GraphicColor ;
+
+  -- TODO: should this semantic value be validated against sbnd1?
+  sbnd2 = Location ;
+
+  sres2 = UnsignedNum 2 ;
+
+  -- TODO: refactor this into other subheaders
+  sxshdl = Choose {
+    notre = @(IsNum 5 0) ;
+    taggedrec = BoundedNum 5 3 9741
+  } ;
+
+  xssofl = Choose {
+    nooverflow = IsNum 3 0 ;
+    desseq = PosNumber 3 ;
+    omitted = sxshdl is notre ;
+  } ;
+
+  sxshd = Choose {
+    tre = {
+      seq = sxshdl is taggedrec ;
+      Many (seq as! uint 64) Byte
+    } ;
+    ommitted = sxshdl is notre
+  } ;
+}

--- a/nitf/nitf-modern/nitf_graphic_subheader.ddl
+++ b/nitf/nitf-modern/nitf_graphic_subheader.ddl
@@ -39,18 +39,18 @@ def GraphicHeader = {
   sres2 = UnsignedNum 2 ;
 
   -- TODO: refactor this into other subheaders
-  sxshdl = Choose { -- NOTE-MODERN: This seems to overlap!!!
+  sxshdl = Choose { -- NOTE-MODERN: nonoverlapping
     notre = @(IsNum 5 0) ;
     taggedrec = BoundedNum 5 3 9741
   } ;
 
-  xssofl = Choose { -- NOTE-MODERN: This seems to overlap!!!
+  xssofl = Choose { -- NOTE-MODERN: This may overlap!!!
     nooverflow = IsNum 3 0 ;
     desseq = PosNumber 3 ;
     omitted = sxshdl is notre ;
   } ;
 
-  sxshd = Choose { -- NOTE-MODERN: This seems to overlap!!!
+  sxshd = Choose { -- NOTE-MODERN: This may overlap!!!
     tre = {
       seq = sxshdl is taggedrec ;
       Many (seq as! uint 64) Byte

--- a/nitf/nitf-modern/nitf_header.ddl
+++ b/nitf/nitf-modern/nitf_header.ddl
@@ -1,0 +1,260 @@
+import nitf_lib
+
+-- Wrap a value in a Maybe
+
+def CallMeMaybe P = { @r = P; ^ just r}
+
+{-- Field parsers --}
+
+def FHDR = Match "NITF"
+
+def FVER = Match "02.10"
+
+-- Valid values 01 .. 99
+def CLEVEL ={
+  @l = UnsignedNum 2;
+  Guard (l != 0);
+  ^l;
+}
+
+def STYPE = Match "BF01"
+
+def OSTAID =
+  block
+    bs = Many 10 BCSA;
+    Guard (bs != "0000000000");
+
+def FDT = DateTime
+
+def FTITLE = Many 80 ECSA
+
+def FSCLAS = Match1 ('T' | 'S' | 'C' | 'R' | 'U')
+
+def Digraph = Many (1..) (Match1 ('A'..'Z'))
+
+-- TODO: Field must contain valid codes per FIPS PUB 10-4, "XN", or "  "
+-- TODO: Field must be set if any of the following are set: FSCODE,
+--       FSREL, FSDCTP, FSDCDT, FSDCXM, FSDG, FSDGDT, FSCLTX, FSCATP,
+--       FSCAUT, FSCRSN, FSSRDT, and FSCTLN
+def FSCLSY = Digraph | Match "  "
+
+def DigraphSeq = Choose1 {
+  { @d = Digraph;
+    @ds = Many { Match1 ' '; $$ = Digraph};
+    Many (Match1 ' ');
+    END;
+    ^ just (concat [ [d], ds ]) };
+  {Many (Match1 ' '); END; ^ nothing};
+}
+
+
+-- def FSCODE = Many 11 ' ' -- Chunk 11 DigraphSeq
+def FSCODE = Chunk 11 DigraphSeq
+
+
+def FSCTLH = Digraph | Match "  "
+
+-- def FSREL = Many 20 ' ' -- Chunk 20 DigraphSeq
+def FSREL = Chunk 20 DigraphSeq
+
+-- Unclear how to pad single characters here...
+def FSDCTP = Choose {
+  dd = @Match "DD" ;
+  de = @Match "DE" ;
+  gd = @Match "GD" ;
+  ge = @Match "GE" ;
+  o  = @Match "O " ;
+  x  = @Match "X " ;
+  none = @Match "  " ;
+}
+
+-- TODO Add proper date parsing
+def Date2 = Many 8 ECSA
+
+-- padding again
+def FSDCXM =
+  [ Match1 ' '; Match1 ' '; Match1 'X'; Match1 ('1' .. '8') ] |
+  [ Match1 'X'; Match1 ('1' .. '8'); Match1 ' '; Match1 ' ' ] |
+  [ Match1 'X'; Match1 '2'; Match1 '5'; Match1 ('1' .. '9') ]
+
+def FSDG = Match1 ('S' | 'C' | 'R')
+
+def FSDGDT = Many 8 ECSA
+
+def FSCLTX = Many 43 ECSA
+
+def FS_declass = {
+  declass_type = FSDCTP;
+  fsdcdt = Choose1 {
+    { declass_type is dd; CallMeMaybe Date2 };
+    { Many 8 (Match1 ' '); ^ nothing };
+  };
+  fsdcxm = Choose1 {
+    { declass_type is x; @f = FSDCXM; ^ just f};
+    { Many 4 (Match1 ' '); ^ nothing };
+  };
+  fsdg = Choose1 {
+    { declass_type is gd | declass_type is ge;
+      @f = FSDG; ^ just f};
+    { Match1 ' '; ^ nothing };
+  };
+  fsdgdt = Choose1 {
+    { declass_type is gd; @d = Date2; ^ just d};
+    { Many 8 (Match1 ' '); ^ nothing};
+  };
+  fscltx = Choose1 {
+    { declass_type is de | declass_type is ge;
+      CallMeMaybe (@Many 43 ECSA) };
+    { Many 43 (Match1 ' '); ^ nothing}
+  }
+}
+
+def FSC_auth = Choose1 {
+  { CallMeMaybe {
+      type = Match1 ('O' | 'D' | 'M');
+      auth = Many 40 ECSA;
+    }
+  };
+  { Match1 ' '; Many 40 ECSA; ^ nothing};
+}
+
+def FSCRSN = Match1 ('A' .. 'G' | ' ')
+
+def FSSRDT = Many 8 ECSA
+
+def FSCTLN = Many 15 ECSA
+
+def FSCOP = Many 5 BCSN
+
+def FSCPYS = Many 5 BCSN
+
+def ENCRYP = BCSN
+
+-- The nonstandard_utf8 case is a magic sequence that isn't defined in the
+-- NITF standard, but is handled in the Hammer parser
+def FBKGC =
+  Choose1 {
+    nonstandard_utf8 = Many 3 {Match [0xef; 0xbf; 0xbd]; ^ 0xbd} : [uint 8]; -- XXX: This seems wrong.
+    normal = Many 3 (Match1 (0x00 .. 0xFF));
+  }
+
+def ONAME = Many 24 ECSA
+
+def OPHONE = Many 18 ECSA
+
+def FL = Choose1 {
+  unknown_length = Many 12 (Match1 '9');
+  -- TODO put interval bounds here:
+  file_length = UnsignedNum 12 ;
+}
+
+def HL = UnsignedNum 6
+
+-- TODO: refactor this into code that computes max for some number of UnsignedNums
+
+def ImgLens = {
+  lish = BoundedNum 6 439 999998 ;
+  li = BoundedPos 10 9999999999
+}
+
+-- GraphLens: lengths of graphic segments:
+def GraphLens = {
+  lssh = BoundedNum 4 258 9999 ;
+  seglen = BoundedPos 6 999999
+}
+
+def NUMX = Match "000"
+
+def LTSH = Many 4 BCSN
+def LT = Many 5 BCSN
+
+def TextLens = {
+  ltsh = BoundedNum 4 282 9999 ;
+  lt = BoundedPos 5 999999
+}
+
+def DataExtLens = {
+  ldsh = BoundedNum 4 200 9999 ;
+  ld = BoundedPos 9 999999999
+}
+
+def LRESH = Many 4 BCSN
+def LRE = Many 7 BCSN
+
+def ResExtLens = {
+  lresh = BoundedNum 4 200 9999 ;
+  lre = BoundedPos 7 9999999
+}
+
+def UDHDL = Many 5 BCSN
+
+def UserData = Choose1 {
+                 none = { Match "00000"; ^ {} } ;
+                 udhd = {@l = UnsignedNum 5 as! uint 64;
+                         overflow = Many 3 BCSN;
+                         data = Many (l - 3) UInt8; };
+               }
+
+
+{-- Main header parser --}
+
+def Header = {
+  FHDR;
+  fver = FVER;
+  clevel = CLEVEL;
+  STYPE;
+  ostaid = OSTAID;
+  fdt = FDT;
+
+  -- check that the file was created after epoch
+  @ep = Epoch ;
+  OrdDate ep fdt.date ;
+
+  -- check that the file was created no later than the current date
+  @today = Today ;
+  OrdDate fdt.date today ;
+
+  ftitle = FTITLE;
+  fsclas = FSCLAS;
+  fsclsy = FSCLSY;
+  fscode = FSCODE;
+  fsctlh = FSCTLH;
+  fsrel = FSREL;
+
+  fs_declass = FS_declass;
+
+  fsc_auth = FSC_auth;
+
+  fscrsn = FSCRSN;
+  fssrdt = FSSRDT;
+  fsctln = FSCTLN;
+  fscop = FSCOP;
+  fscpys = FSCPYS;
+  encryp = ENCRYP;
+  fbkgc = FBKGC;
+  oname = ONAME;
+  ophone = OPHONE;
+  fl = FL;
+  hl = HL;
+
+  numi = UnsignedNum 3 ;
+  li = Many (numi as! uint 64) ImgLens ;
+
+  nums = UnsignedNum 3 ;
+  graphlens = Many (nums as! uint 64) GraphLens ;
+
+  NUMX;
+  @numt = UnsignedNum 3 ;
+  textlens = Many (numt as! uint 64) TextLens ;
+
+  @numdes = UnsignedNum 3 ;
+  dataextlens = Many (numdes as! uint 64) DataExtLens ;
+
+  @numres = UnsignedNum 3 ;
+  resextlens = Many (numres as! uint 64) ResExtLens ;
+
+  lre = Many (numres as! uint 64) [LRESH; LRE];
+
+  udhd = UserData;
+  xhd = UserData;
+}

--- a/nitf/nitf-modern/nitf_header.ddl
+++ b/nitf/nitf-modern/nitf_header.ddl
@@ -58,6 +58,7 @@ def FSCTLH = Digraph | Match "  "
 def FSREL = Chunk 20 DigraphSeq
 
 -- Unclear how to pad single characters here...
+-- NOTE-MODERN: nonoverlapping
 def FSDCTP = Choose {
   dd = @Match "DD" ;
   de = @Match "DE" ;

--- a/nitf/nitf-modern/nitf_header.ddl
+++ b/nitf/nitf-modern/nitf_header.ddl
@@ -58,8 +58,7 @@ def FSCTLH = Digraph | Match "  "
 def FSREL = Chunk 20 DigraphSeq
 
 -- Unclear how to pad single characters here...
--- NOTE-MODERN: nonoverlapping
-def FSDCTP = Choose {
+def FSDCTP = Choose { -- NOTE-MODERN: nonoverlapping
   dd = @Match "DD" ;
   de = @Match "DE" ;
   gd = @Match "GD" ;

--- a/nitf/nitf-modern/nitf_img_subheader.ddl
+++ b/nitf/nitf-modern/nitf_img_subheader.ddl
@@ -346,7 +346,7 @@ def IRepBandN = Choose { -- NOTE-MODERN: nonoverlapping
   default = @(Spaces 2) ;
 }
 
-def ISubCatN = Choose {
+def ISubCatN = Choose1 { -- NOTE-MODERN: changed to `Choose1` to prevent overlapping of `default` and `userdef` with space `0x20`.
   inphase = @(PadMatch 6 ' ' "I") ;
   quadrature = @(PadMatch 6 ' ' "Q") ;
   magnitude = @(PadMatch 6 ' ' "M") ;
@@ -379,7 +379,7 @@ def IMode nbands = {
     row = @Match1 'R' ;
     seq = @Match1 'S' ;
   } ;
-  Guard (nbands != 1) | $$ is blockMode
+  Guard (nbands != 1) <| $$ is blockMode  -- NOTE-MODERN: Fix using <| to prevent multiple parse
 }
 
 def NBPR = PosQuad

--- a/nitf/nitf-modern/nitf_img_subheader.ddl
+++ b/nitf/nitf-modern/nitf_img_subheader.ddl
@@ -48,7 +48,7 @@ def NRows = PosNumber 8
 
 def NCols = PosNumber 8
 
-def PVType = Choose {
+def PVType = Choose { -- NOTE-MODERN: nonoverlapping
   integer = @(PadMatch 3 ' ' "INT") ;
   bilevel = @(PadMatch 3 ' ' "B") ;
   signed = @(PadMatch 3 ' ' "SI") ;
@@ -56,19 +56,19 @@ def PVType = Choose {
   complex = @(PadMatch 3 ' ' "C") ;
 }
 
-def IRep = Choose {
+def IRep = Choose { -- NOTE-MODERN: nonoverlapping
   monochrome = @(PadMatch 8 ' ' "MONO") ;
   rgb = @(PadMatch 8 ' ' "RGB") ;
   rgblut = @(PadMatch 8 ' ' "RGB/LUT") ;
-  multi = @(PadMatch 8 ' ' "MULTI") ; 
+  multi = @(PadMatch 8 ' ' "MULTI") ;
   nodisplay = @(PadMatch 8 ' ' "NODISPLY") ;
   cartesian = @(PadMatch 8 ' ' "NVECTOR") ;
   polar = @(PadMatch 8 ' ' "POLAR") ;
-  sar = @(PadMatch 8 ' ' "VPH") ; 
+  sar = @(PadMatch 8 ' ' "VPH") ;
   itur = @(PadMatch 8 ' ' "YCbCr601") ;
 }
 
-def ICat = Choose {
+def ICat = Choose { -- NOTE-MODERN: nonoverlapping
   visible = @(PadMatch 8 ' ' "VIS") ;
   sideLooking = @(PadMatch 8 ' ' "SL") ;
   thermalInfrared = @(PadMatch 8 ' ' "TI") ;
@@ -104,13 +104,13 @@ def ICat = Choose {
 
 def ABPP = BoundedNum 2 1 96
 
-def PJust = Choose {
+def PJust = Choose { -- NOTE-MODERN: nonoverlapping
   leftJust = @Match1 'L' ;
   rightJust = @Match1 'R' ;
 }
 
 def ICords = DefaultSpace (
-  Choose {
+  Choose { -- NOTE-MODERN: nonoverlapping
     utm = @Match1 'U' ;
     northernhemi = @Match1 'N' ;
     southernhemi = @Match1 'S' ;
@@ -140,7 +140,7 @@ def LongDeg = {
 
 def Latitude = {
   digs = PadMany 6 ' ' Numeral ;
-  hemi = Choose {
+  hemi = Choose { -- NOTE-MODERN: non-overlapping
     north = @Match1 'N' ;
     south = @Match1 'S' ;
   }
@@ -148,7 +148,7 @@ def Latitude = {
 
 def Longitude = {
   digs = PadMany 7 ' ' Numeral ;
-  hemi = Choose {
+  hemi = Choose { -- NOTE-MODERN: non-overlapping
     east = @Match1 'E' ;
     west = @Match1 'W' ;
   }
@@ -166,7 +166,7 @@ def UtmZone = {
 def FiveDigitNum = {
   @v = Many 5 Digit ;
   ^ numBase 10 v
-} 
+}
 
 def PlainUtm = {
   utm = Many 2 Numeral ;
@@ -175,8 +175,8 @@ def PlainUtm = {
 }
 
 def OmitIO lb ub = Match1 (
-  lb .. 'H' 
-| 'J' .. 'N' 
+  lb .. 'H'
+| 'J' .. 'N'
 | 'P' .. ub
 )
 
@@ -200,6 +200,7 @@ def EqLat l0 l1 = {
 -- TODO: refine this to allow only rectangles or triangles
 --XXX: This can be one single expression
 def OrdLong left right =
+-- NOTE-MODERN: That seems nonoverlapping
   { Guard (left.sign == '-') ; Guard (right.sign == '+') }
 | { Guard (left.sign == right.sign) ;
     (  { Guard (left.sign == '-') ;
@@ -211,7 +212,7 @@ def OrdLong left right =
          | { Guard (left.whole == right.whole) ;
              Guard (left.frac <= right.frac) } } ) }
 
-def IGeoLo = Choose {
+def IGeoLo = Choose { -- NOTE-MODERN: TODO: decide on that one...
   decimal_degs = {
     lat0 = LatDeg ;
     long0 = LongDeg ;
@@ -235,7 +236,7 @@ def NICom = Digit as! uint 64
 
 def IComn n = Many n (Many 80 Byte)
 
-def IC = Choose {
+def IC = Choose { -- NOTE-MODERN: nonoverlapping
   c1 = @Match "C1" ;
   c3 = @Match "C3" ;
   c4 = @Match "C4" ;
@@ -255,16 +256,16 @@ def IC = Choose {
   nm = @Match "NM" ;
 }
 
-def ComRat (ic : IC) = Choose {
-  dim_coding = { 
+def ComRat (ic : IC) = Choose { -- NITF-MODERN: that seems nonoverlapping
+  dim_coding = {
       ic is c1
     | ic is m1 ;
-    Choose {
+    Choose { -- NOTE-MODERN: nonoverlapping
       oned = @(PadMatch 4 ' ' "1D") ;
       twods = @(PadMatch 4 ' ' "2DS") ;
       twodh = @(PadMatch 4 ' ' "2DH") ;
     } ;
-  } ; 
+  } ;
   quant_tables = {
       ic is c3
     | ic is c5
@@ -281,7 +282,7 @@ def ComRat (ic : IC) = Choose {
     | {   ic is c3
         | ic is i1
         | ic is m3 }
-  } ; 
+  } ;
   bits_per_pixel = {
       ic is c4
     | ic is m4 ;
@@ -329,10 +330,10 @@ def NBands (irep : IRep) = (
   }
 | IsNum 1 0
 )
-  
+
 def XBands n = BoundedNum 5 10 99999
 
-def IRepBandN = Choose {
+def IRepBandN = Choose { -- NOTE-MODERN: nonoverlapping
   bandM = @(PadMatch 2 ' ' "M") ;
   lutBand = @(PadMatch 2 ' ' "LU") ;
   red = @(PadMatch 2 ' ' "R") ;
@@ -360,7 +361,7 @@ def ISubCatN = Choose {
   default = @(Spaces 6) ;
   userdef = Many 6 BCSA ;
 }
-  
+
 def IFCN = Match1 'N'  -- other values reserved for future use
 
 def ImFltN = Spaces 3 -- reserved for future use
@@ -372,7 +373,7 @@ def LutdNM n = Many n Byte
 def ISync = Match1 '0' -- reserved for future use
 
 def IMode nbands = {
-  $$ = Choose {
+  $$ = Choose { -- NOTE-MODERN: nonoverlapping
     blockMode = @Match1 'B' ;
     pixel = @Match1 'P' ;
     row = @Match1 'R' ;
@@ -431,12 +432,12 @@ def IMag = Choose {
     Guard (fplen <= 4) ;
     Spaces (4 - fplen)
   } ;
-  frac = { 
+  frac = {
     Match1 '/' ;
     $$ = Many (..3) Digit ;
     @fplen = ^ (length $$) + 1 ;
     Guard (fplen <= 4) ;
-    Spaces (4 - fplen) 
+    Spaces (4 - fplen)
   }
 }
 
@@ -576,7 +577,7 @@ def CatParams (icat : ICat) (isubcat : ISubCatN) nbands (pvtype : PVType) nbpp a
         Guard (abpp == 1) }
     | {   Guard (nbands == 1)
         | Guard (nbands == 3) ;
-          { pvtype is integer ; CatIntFull nbpp abpp } 
+          { pvtype is integer ; CatIntFull nbpp abpp }
         | { pvtype is real ; CatReals nbpp abpp } } }
 | {   icat is sideLooking
     | icat is thermalInfrared
@@ -599,7 +600,7 @@ def CatParams (icat : ICat) (isubcat : ISubCatN) nbands (pvtype : PVType) nbpp a
     Guard (nbands == 1) ;
       { pvtype is integer ; CatIntFull nbpp abpp }
     | { pvtype is real ; CatReals nbpp abpp } }
-| {   icat is colorPhoto 
+| {   icat is colorPhoto
     | icat is colorPatch ;
       isubcat is default
     | @(isubcat is userdef) ;
@@ -735,7 +736,7 @@ def ISHeader = {
 
   nbands = NBands irep ;
 
-  xbands = Choose {
+  xbands = Choose { -- NOTE-MODERN: nonoverlapping
     def_xband = {
       Guard (nbands == 0) ;
       XBands nbands
@@ -767,14 +768,14 @@ def ISHeader = {
     -- check display params
     DispParams irep irepbandn nbands pvtype nlutsn ;
 
-    Choose {
+    Choose { -- NOTE-MODERN: nonoverlapping
       luts = {
         Guard (nlutsn > 0) ;
         nelutn = NELutN ;
         lutd_nm = LutdNM nlutsn ;
       } ;
       no_luts = Guard (nlutsn == 0)
-    } 
+    }
   } ;
 
   ISync ;
@@ -783,7 +784,7 @@ def ISHeader = {
   nbpr = NBPR ;
   -- TODO: rework to remove negations
   nbpc = NBPC ;
-    (Guard (nbpr != 1) | Guard (nbpc != 1))
+    (Guard (nbpr != 1) | Guard (nbpc != 1)) --  NOTE-MODERN: overlapping bug does not seem to make the difference when fixed
   | (imode is blockMode | imode is pixel | imode is row);
   -- is R really allowed? Needed by i_3201c.ntf.
 
@@ -806,7 +807,7 @@ def ISHeader = {
   imag = IMag ;
 
   udidl = UDIDL ;
-  Choose {
+  Choose { -- NOTE-MODERN: no overlapping
     uds = {
       Guard (udidl > 0) ;
       udofl = UDOfl ;
@@ -816,7 +817,7 @@ def ISHeader = {
   } ;
 
   ixshdl = IXShDL ;
-  Choose {
+  Choose { -- NOTE-MODERN: no overlapping
     ixs = {
       Guard (ixshdl > 0) ;
       ixsofl = IXSOfl ;

--- a/nitf/nitf-modern/nitf_img_subheader.ddl
+++ b/nitf/nitf-modern/nitf_img_subheader.ddl
@@ -1,0 +1,827 @@
+import nitf_lib
+
+-- functions over pure values:
+
+-- DOC: is the result of an leq or equality test a raw value or a grammar
+
+-- DOC: discuss type annotations vs. coercions
+
+-- DOC: list introduction forms
+
+-- TODO: check uses of this
+def Maybe guard P =
+  { Match guard ; @v = P ; ^ just v} <|
+  ^ nothing
+
+def DateDefaultSpaces = DefaultSpaces 8 PartialDate
+
+-- image subheader fields:
+
+def Im = Match "IM"
+
+def IID1 = Many 10 (AlphaNum | Match1 ('_' | ' '))
+
+def IDaTim = PartialDateTime
+
+-- BE: basic encyclopedia
+def BE = Many 10 AlphaNum
+
+def OSuffix = Many 5 AlphaNum
+
+def TgtId = {
+  be = DefaultSpaces 10 BE ;
+  osuffix = DefaultSpaces 5 OSuffix ;
+  country = DefaultSpaces 2 CountryCode
+}
+
+def IID2 = Many 80 Byte
+
+-- SeqWs: a sequence of P's of size k, padded by spaces to be n bytes
+-- def SeqWs k n P = DefaultSpaces n { P ; SeqWs k (n - k) P }
+-- DOC: why is this not a valid recursive type?
+
+-- DOC: handling numeric literals
+
+def ISorce = DefaultSpaces 42 (Many 42 Byte)
+
+def NRows = PosNumber 8
+
+def NCols = PosNumber 8
+
+def PVType = Choose {
+  integer = @(PadMatch 3 ' ' "INT") ;
+  bilevel = @(PadMatch 3 ' ' "B") ;
+  signed = @(PadMatch 3 ' ' "SI") ;
+  real = @(PadMatch 3 ' ' "R") ;
+  complex = @(PadMatch 3 ' ' "C") ;
+}
+
+def IRep = Choose {
+  monochrome = @(PadMatch 8 ' ' "MONO") ;
+  rgb = @(PadMatch 8 ' ' "RGB") ;
+  rgblut = @(PadMatch 8 ' ' "RGB/LUT") ;
+  multi = @(PadMatch 8 ' ' "MULTI") ; 
+  nodisplay = @(PadMatch 8 ' ' "NODISPLY") ;
+  cartesian = @(PadMatch 8 ' ' "NVECTOR") ;
+  polar = @(PadMatch 8 ' ' "POLAR") ;
+  sar = @(PadMatch 8 ' ' "VPH") ; 
+  itur = @(PadMatch 8 ' ' "YCbCr601") ;
+}
+
+def ICat = Choose {
+  visible = @(PadMatch 8 ' ' "VIS") ;
+  sideLooking = @(PadMatch 8 ' ' "SL") ;
+  thermalInfrared = @(PadMatch 8 ' ' "TI") ;
+  forwardLooking = @(PadMatch 8 ' ' "FL") ;
+  radar = @(PadMatch 8 ' ' "RD") ;
+  electroOptical = @(PadMatch 8 ' ' "EO") ;
+  optical = @(PadMatch 8 ' ' "OP") ;
+  highResolution = @(PadMatch 8 ' ' "HR") ;
+  hyperSpectral = @(PadMatch 8 ' ' "HS") ;
+  colorPhoto = @(PadMatch 8 ' ' "CP") ;
+  blackWhitePhoto = @(PadMatch 8 ' ' "BP") ;
+  synthApertureRadar = @(PadMatch 8 ' ' "SAR") ;
+  sarRadioHologram = @(PadMatch 8 ' ' "SARIQ") ;
+  infrared = @(PadMatch 8 ' ' "IR") ;
+  multiSpectral = @(PadMatch 8 ' ' "MS") ;
+  fingerprints = @(PadMatch 8 ' ' "FP") ;
+  mri = @(PadMatch 8 ' ' "MRI") ;
+  xray = @(PadMatch 8 ' ' "XRAY") ;
+  catScans = @(PadMatch 8 ' ' "CAT") ;
+  video = @(PadMatch 8 ' ' "VD") ;
+  barometric = @(PadMatch 8 ' ' "BARO") ;
+  waterCurrent = @(PadMatch 8 ' ' "CURRENT") ;
+  waterDepth = @(PadMatch 8 ' ' "DEPTH") ;
+  airWind = @(PadMatch 8 ' ' "WIND") ;
+  -- geographic products:
+  rasterMap = @(PadMatch 8 ' ' "MAP") ;
+  colorPatch = @(PadMatch 8 ' ' "PAT") ;
+  legends = @(PadMatch 8 ' ' "LEG") ;
+  elevationModel = @(PadMatch 8 ' ' "DTEM") ;
+  otherMatrix = @(PadMatch 8 ' ' "MATR") ;
+  locationGrid = @(PadMatch 8 ' ' "LOCG") ;
+}
+
+def ABPP = BoundedNum 2 1 96
+
+def PJust = Choose {
+  leftJust = @Match1 'L' ;
+  rightJust = @Match1 'R' ;
+}
+
+def ICords = DefaultSpace (
+  Choose {
+    utm = @Match1 'U' ;
+    northernhemi = @Match1 'N' ;
+    southernhemi = @Match1 'S' ;
+    geographic = @Match1 'G' ;
+    decimal = @Match1 'D' ;
+  })
+
+def LatDeg = {
+  sign = Sign ;
+  @whole_digs = Many 2 Digit ;
+  whole = ^ numBase 10 whole_digs ;
+  Match1 '.' ;
+  @frac_digs = Many 3 Digit ;
+  frac = ^ numBase 10 frac_digs ;
+  Guard (whole < 90) | { Guard (whole == 90); Guard (frac == 0) }
+}
+
+def LongDeg = {
+  sign = Sign ;
+  @whole_digs = Many 3 Digit ;
+  whole = ^ numBase 10 whole_digs ;
+  Match1 '.' ;
+  @frac_digs = Many 3 Digit ;
+  frac = ^ numBase 10 frac_digs ;
+  Guard (whole < 180) | { Guard (whole == 180); Guard (frac == 0) }
+}
+
+def Latitude = {
+  digs = PadMany 6 ' ' Numeral ;
+  hemi = Choose {
+    north = @Match1 'N' ;
+    south = @Match1 'S' ;
+  }
+}
+
+def Longitude = {
+  digs = PadMany 7 ' ' Numeral ;
+  hemi = Choose {
+    east = @Match1 'E' ;
+    west = @Match1 'W' ;
+  }
+}
+
+def LatLong = {
+  lat = Latitude ;
+  long = Longitude
+}
+
+def UtmZone = {
+  zone = BoundedNum 2 1 60 ;
+}
+
+def FiveDigitNum = {
+  @v = Many 5 Digit ;
+  ^ numBase 10 v
+} 
+
+def PlainUtm = {
+  utm = Many 2 Numeral ;
+  easting = Many 6 Numeral ;
+  northing = Many 7 Numeral ;
+}
+
+def OmitIO lb ub = Match1 (
+  lb .. 'H' 
+| 'J' .. 'N' 
+| 'P' .. ub
+)
+
+def MGRS = {
+  zone_num = Many 2 Digit ;
+  zone_band = OmitIO 'C' 'X';
+  sq_id = {
+    col_id = OmitIO 'A' 'Z' ;
+    row_id = OmitIO 'A' 'V' ;
+  } ;
+  easting = Many 5 Numeral ;
+  northing = Many 5 Numeral
+}
+
+def EqLat l0 l1 = {
+  Guard (l0.sign == l1.sign) ;
+  Guard (l0.whole == l1.whole) ;
+  Guard (l0.frac == l1.frac)
+}
+
+-- TODO: refine this to allow only rectangles or triangles
+--XXX: This can be one single expression
+def OrdLong left right =
+  { Guard (left.sign == '-') ; Guard (right.sign == '+') }
+| { Guard (left.sign == right.sign) ;
+    (  { Guard (left.sign == '-') ;
+           Guard (left.whole > right.whole)
+         | { Guard (left.whole == right.whole) ;
+             Guard (left.frac >= right.frac) } }
+     | { Guard (left.sign == '+') ;
+           Guard (left.whole < right.whole)
+         | { Guard (left.whole == right.whole) ;
+             Guard (left.frac <= right.frac) } } ) }
+
+def IGeoLo = Choose {
+  decimal_degs = {
+    lat0 = LatDeg ;
+    long0 = LongDeg ;
+    lat1 = LatDeg ;
+    long1 = LongDeg ;
+    lat2 = LatDeg ;
+    long2 = LongDeg ;
+    lat3 = LatDeg ;
+    long3 = LongDeg ;
+    EqLat lat0 lat1 ;
+    EqLat lat2 lat3 ;
+    OrdLong long0 long1 ;
+    OrdLong long3 long2
+  } ;
+  lat_long = Many 4 LatLong ;
+  mgrs = Many 4 MGRS ;
+  plain_utm = Many 4 PlainUtm
+}
+
+def NICom = Digit as! uint 64
+
+def IComn n = Many n (Many 80 Byte)
+
+def IC = Choose {
+  c1 = @Match "C1" ;
+  c3 = @Match "C3" ;
+  c4 = @Match "C4" ;
+  c5 = @Match "C5" ;
+  c6 = @Match "C6" ;
+  c7 = @Match "C7" ;
+  c8 = @Match "C8" ;
+  i1 = @Match "I1" ;
+  m1 = @Match "M1" ;
+  m3 = @Match "M3" ;
+  m4 = @Match "M4" ;
+  m5 = @Match "M5" ;
+  m6 = @Match "M6" ;
+  m7 = @Match "M7" ;
+  m8 = @Match "M8" ;
+  nc = @Match "NC" ;
+  nm = @Match "NM" ;
+}
+
+def ComRat (ic : IC) = Choose {
+  dim_coding = { 
+      ic is c1
+    | ic is m1 ;
+    Choose {
+      oned = @(PadMatch 4 ' ' "1D") ;
+      twods = @(PadMatch 4 ' ' "2DS") ;
+      twodh = @(PadMatch 4 ' ' "2DH") ;
+    } ;
+  } ; 
+  quant_tables = {
+      ic is c3
+    | ic is c5
+    | ic is i1
+    | ic is m3
+    | ic is m5 ;
+    Match1 '0' ;
+    img_data_type = BoundedDigit 0 4;
+    Match1 '.' ;
+    quality_level = BoundedDigit 0 5;
+      {   ic is c5
+        | ic is m5 ;
+        Guard (quality_level == 0) }
+    | {   ic is c3
+        | ic is i1
+        | ic is m3 }
+  } ; 
+  bits_per_pixel = {
+      ic is c4
+    | ic is m4 ;
+    ones = Digit ;
+    Match1 '.' ;
+    tenths = Digit ;
+    hudredths = Digit
+  } ;
+  nominal = {
+      ic is c8
+    | ic is m8 ;
+    Many 4 Byte
+  }
+}
+
+
+def NBands (irep : IRep) = (
+  { irep is nodisplay ;
+    Digit as uint 64;
+  }
+| { irep is monochrome ;
+    IsNum 1 1
+  }
+| { irep is rgb ;
+    IsNum 1 3
+  }
+| { irep is rgblut ;
+    IsNum 1 1
+  }
+| { irep is itur ;
+    IsNum 3 3
+  }
+| { irep is cartesian ;
+    Digit as uint 64
+  }
+| { irep is polar ;
+    IsNum 1 2
+  }
+| { irep is sar ;
+    IsNum 1 1
+  }
+| { irep is multi ;
+      IsNum 1 0
+    | BoundedNum 1 2 9
+  }
+| IsNum 1 0
+)
+  
+def XBands n = BoundedNum 5 10 99999
+
+def IRepBandN = Choose {
+  bandM = @(PadMatch 2 ' ' "M") ;
+  lutBand = @(PadMatch 2 ' ' "LU") ;
+  red = @(PadMatch 2 ' ' "R") ;
+  green = @(PadMatch 2 ' ' "G") ;
+  blue = @(PadMatch 2 ' ' "B") ;
+  monoBand = @(PadMatch 2 ' ' "M") ;
+  luminance = @(PadMatch 2 ' ' "Y") ;
+  chrominanceBlue = @(PadMatch 2 ' ' "Cb") ;
+  chrominanceRed = @(PadMatch 2 ' ' "Cr") ;
+  default = @(Spaces 2) ;
+}
+
+def ISubCatN = Choose {
+  inphase = @(PadMatch 6 ' ' "I") ;
+  quadrature = @(PadMatch 6 ' ' "Q") ;
+  magnitude = @(PadMatch 6 ' ' "M") ;
+  phase = @(PadMatch 6 ' ' "P") ;
+  speed = @(PadMatch 6 ' ' "SPEED") ;
+  direct = @(PadMatch 6 ' ' "DIRECT") ;
+  easting = @(PadMatch 6 ' ' "CGX") ;
+  northing = @(PadMatch 6 ' ' "CGY") ;
+  longitude = @(PadMatch 6 ' ' "GGX") ;
+  latitude = @(PadMatch 6 ' ' "GGY") ;
+  waveLength = UnsignedNum 6 ;
+  default = @(Spaces 6) ;
+  userdef = Many 6 BCSA ;
+}
+  
+def IFCN = Match1 'N'  -- other values reserved for future use
+
+def ImFltN = Spaces 3 -- reserved for future use
+
+def NELutN = BoundedPos 5 65536
+
+def LutdNM n = Many n Byte
+
+def ISync = Match1 '0' -- reserved for future use
+
+def IMode nbands = {
+  $$ = Choose {
+    blockMode = @Match1 'B' ;
+    pixel = @Match1 'P' ;
+    row = @Match1 'R' ;
+    seq = @Match1 'S' ;
+  } ;
+  Guard (nbands != 1) | $$ is blockMode
+}
+
+def NBPR = PosQuad
+
+def NBPC = PosQuad
+
+def NPPBH = UpperBounded 4 8192
+
+def NPPBV = UpperBounded 4 8192
+
+def NBPP abpp (ic : IC) = {
+  $$ = BoundedPos 2 96 ;
+  Guard ($$ >= abpp) ;
+    {   ic is c3
+      | ic is c5
+      | ic is i1
+      | ic is m3
+      | ic is m5 ;
+        Guard ($$ == 8)
+      | Guard ($$ == 12) }
+  | { ic is c1 ;
+      Guard ($$ == 1) }
+  | {   ic is c1
+      | ic is m8 ;
+      Guard (1 <= $$) ; Guard ($$ <= 38) }
+  | {   ic is c4
+      | ic is c6
+      | ic is c7
+      | ic is c8
+      | ic is m1
+      | ic is m4
+      | ic is m6
+      | ic is m7
+      | ic is nc
+      | ic is nm }
+}
+
+def IDLvl = BoundedNum 3 1 999
+
+-- TODO: this and image display level need to satisfy a global
+-- property over all image segments
+
+def IALvl = AttachmentLvl
+
+def IMag = Choose {
+  fp = {
+    $$ = FixedPoint ;
+    @fplen = ^ (length $$.digs) + 1 + (length $$.radix) ;
+    -- DOC: why was this hard to refactor?
+    Guard (fplen <= 4) ;
+    Spaces (4 - fplen)
+  } ;
+  frac = { 
+    Match1 '/' ;
+    $$ = Many (..3) Digit ;
+    @fplen = ^ (length $$) + 1 ;
+    Guard (fplen <= 4) ;
+    Spaces (4 - fplen) 
+  }
+}
+
+def UDIDL = LowerBoundedOrZero 5 3 as! uint 64
+
+def UDOfl = UnsignedNum 3
+
+def UDID n = Many (n - 3) Byte
+
+def IXShDL = LowerBoundedOrZero 5 3 as! uint 64
+
+def IXSOfl = UnsignedNum 3
+
+def IXShD n = Many (n - 3) Byte
+
+-- encoding of display-dependent parameters (Table A-2)
+def DispParams (irep : IRep) (irepband : IRepBandN) nbands (pvtype : PVType) nluts =
+  { irep is nodisplay ;
+    irepband is default ;
+      { Guard (1 <= nbands) ; Guard (nbands <= 9) }
+    | Guard (nbands == 0) ;
+      pvtype is integer
+    | pvtype is real
+    | pvtype is complex
+    | pvtype is bilevel
+    | pvtype is signed ;
+    Guard (nluts == 0) }
+| { irep is monochrome ;
+      irepband is lutBand
+    | irepband is monoBand
+    | irepband is default;
+    Guard (nbands == 1);
+      pvtype is integer
+    | pvtype is real
+    | pvtype is bilevel ;
+    Guard (0 <= nluts) ; Guard (nluts <= 2) }
+| { irep is rgb ;
+      irepband is red
+    | irepband is green
+    | irepband is blue ;
+    Guard (nbands == 3);
+      pvtype is integer
+    | pvtype is real ;
+    Guard (nluts == 0) }
+| { irep is rgblut ;
+    irepband is lutBand ;
+    Guard (nbands == 1) ;
+      pvtype is integer
+    | pvtype is real ;
+    Guard (nluts == 3) }
+| { irep is itur ;
+      irepband is luminance
+    | irepband is chrominanceBlue
+    | irepband is chrominanceRed ;
+    Guard (nbands == 3) ;
+    pvtype is integer ;
+    Guard (nluts == 0) }
+| { irep is cartesian ;
+    irepband is default ;
+      { Guard (1 <= nbands) ; Guard (nbands <=  9) }
+    | Guard (nbands == 0) ;
+      pvtype is integer
+    | pvtype is real
+    | pvtype is complex ;
+    Guard (nluts == 0) }
+| { irep is polar ;
+      irepband is default
+    | irepband is monoBand ;
+    Guard (nbands == 2) ;
+      pvtype is integer
+    | pvtype is real
+    | pvtype is complex ;
+    Guard (nluts == 0) }
+| { irep is sar ;
+    irepband is default ;
+    Guard (nbands == 2) ;
+      pvtype is integer
+    | pvtype is real
+    | pvtype is complex ;
+    Guard (nluts == 0) }
+| { irep is multi ;
+      irepband is default
+    | irepband is monoBand
+    | irepband is red
+    | irepband is green
+    | irepband is blue
+    | irepband is lutBand ;
+      { Guard (2 <= nbands) ; Guard (nbands <= 9) }
+    | Guard (nbands == 0) ;
+    Guard (0 <= nluts) ; Guard (nluts <= 3)
+  }
+
+def CatIntLow nbpp abpp = {
+  Guard (nbpp == 8) ;
+  Guard (2 <= abpp) ; Guard (nbpp <= 8)
+}
+
+def CatIntMid nbpp abpp =
+  { Guard (nbpp == 12) ;
+    Guard (8 <= abpp) ; Guard (nbpp <= 12) }
+| { Guard (nbpp == 16) ;
+    Guard (9 <= abpp) ; Guard (nbpp <= 16) }
+
+def CatIntHigh nbpp abpp =
+  { Guard (nbpp == 32) ;
+    Guard (17 <= abpp) ; Guard (nbpp <= 32) }
+| { Guard (nbpp == 64) ;
+    Guard (33 <= abpp) ; Guard (nbpp <= 64) }
+
+def CatIntEnds nbpp abpp =
+  CatIntLow nbpp abpp
+| CatIntHigh nbpp abpp
+
+def CatIntFull nbpp abpp =
+  CatIntEnds nbpp abpp
+| CatIntMid nbpp abpp
+
+def CatReals nbpp abpp =
+  { Guard (nbpp == 32) ; Guard (abpp == 32) }
+| { Guard (nbpp == 64) ; Guard (abpp == 64) }
+
+def CatComplex nbpp abpp = {
+  Guard (nbpp == 64) ;
+  Guard (abpp == 64)
+}
+
+-- CatParams: formalization of Table A-2(A)
+-- DOC: is there a way to do total pattern matching on a sum type?
+def CatParams (icat : ICat) (isubcat : ISubCatN) nbands (pvtype : PVType) nbpp abpp =
+  {   icat is visible
+    | icat is optical ;
+      isubcat is default
+    | @(isubcat is userdef) ;
+      { Guard (nbands == 1) ;
+        pvtype is bilevel ;
+        Guard (nbpp == 1) ;
+        Guard (abpp == 1) }
+    | {   Guard (nbands == 1)
+        | Guard (nbands == 3) ;
+          { pvtype is integer ; CatIntFull nbpp abpp } 
+        | { pvtype is real ; CatReals nbpp abpp } } }
+| {   icat is sideLooking
+    | icat is thermalInfrared
+    | icat is forwardLooking
+    | icat is radar
+    | icat is electroOptical
+    | icat is highResolution
+    | icat is blackWhitePhoto
+    | icat is fingerprints
+    | icat is video
+    | icat is catScans
+    | icat is mri
+    | icat is xray ;
+      isubcat is default
+    | @(isubcat is userdef) ;
+    Guard (nbands == 1) ;
+      { pvtype is integer ; CatIntFull nbpp abpp }
+    | { pvtype is real ; CatReals nbpp abpp } }
+| { icat is infrared ;
+    Guard (nbands == 1) ;
+      { pvtype is integer ; CatIntFull nbpp abpp }
+    | { pvtype is real ; CatReals nbpp abpp } }
+| {   icat is colorPhoto 
+    | icat is colorPatch ;
+      isubcat is default
+    | @(isubcat is userdef) ;
+    Guard (nbands == 3) ;
+    pvtype is integer ; CatIntEnds nbpp abpp }
+| {   icat is rasterMap
+    | icat is legends ;
+      isubcat is default
+    | @(isubcat is userdef) ;
+      Guard (nbands == 1)
+    | Guard (nbands == 3) ;
+    pvtype is integer ; CatIntEnds nbpp abpp }
+| { icat is locationGrid ;
+      isubcat is easting
+    | isubcat is northing
+    | isubcat is longitude
+    | isubcat is latitude ;
+    Guard (nbands == 2) ;
+      {   pvtype is integer
+        | pvtype is signed ;
+        CatIntFull nbpp abpp }
+    | { pvtype is real ; CatReals nbpp abpp } }
+| { icat is otherMatrix ;
+    isubcat is userdef ;
+    Guard (1 <= nbands) ; Guard (nbands <= 9) ;
+      { pvtype is complex ; CatComplex nbpp abpp }
+    | {   pvtype is integer
+        | pvtype is signed ;
+        CatIntFull nbpp abpp }
+    | { pvtype is real ; CatReals nbpp abpp } }
+| {   icat is multiSpectral
+    | icat is hyperSpectral ;
+      @(isubcat is waveLength)
+    | isubcat is default ; -- required for milsamples, but does it match spec?
+      { Guard (2 <= nbands) ; Guard (nbands <= 9) }
+    | Guard (nbands == 0) ;
+      {   pvtype is integer
+        | pvtype is signed ;
+        CatIntFull nbpp abpp }
+    | { pvtype is real ; CatReals nbpp abpp } }
+| {   icat is synthApertureRadar
+    | icat is sarRadioHologram ;
+      isubcat is inphase
+    | isubcat is quadrature
+    | isubcat is magnitude
+    | isubcat is phase
+    | isubcat is default ;
+      { Guard (nbands == 1) ; pvtype is complex ; CatComplex nbpp abpp }
+    | {   Guard (nbands == 1)
+        | Guard (nbands == 2) ;
+          {   pvtype is integer
+            | pvtype is signed ;
+            CatIntFull nbpp abpp }
+        | { pvtype is real ; CatReals nbpp abpp } } }
+| {   icat is airWind
+    | icat is waterCurrent ;
+      isubcat is speed
+    | isubcat is direct ;
+    Guard (nbands == 2) ;
+    pvtype is integer ;
+    Guard (nbpp == 8) ;
+    Guard (2 <= abpp) ; Guard (abpp <= 8) }
+| {   icat is barometric
+    | icat is waterDepth ;
+    Guard (nbands == 1) ;
+    pvtype is integer ;
+      CatIntLow nbpp abpp
+    | CatIntMid nbpp abpp }
+| { icat is elevationModel ;
+    Guard (nbands == 1) ;
+      {   pvtype is integer
+        | pvtype is signed ;
+        CatIntFull nbpp abpp }
+    | { pvtype is real ; CatReals nbpp abpp } }
+
+-- ISHeader: an image segment header
+def ISHeader = {
+  Im ;
+  iid1 = IID1 ;
+  idatim = IDaTim ;
+  tgt_id = TgtId ;
+  iid2 = IID2 ;
+
+  -- TODO: these fields overlap with many other subheaders and could
+  -- be refactored
+  common = CommonSubheader ;
+
+  Encryp ;
+
+  i_sorce = ISorce ;
+  n_rows = NRows ;
+  n_cols = NCols ;
+  pvtype = PVType ;
+  irep = IRep ;
+  icat = ICat ;
+  abpp = ABPP ;
+  p_just = PJust ;
+
+  icords = ICords ;
+  Choose {
+    igeolo = {
+      icords is actual ;
+      IGeoLo
+    } ;
+    empty = icords is default
+  };
+
+  nicom = NICom ;
+  i_com_n = IComn nicom ;
+
+  ic = IC ;
+
+  Choose {
+    comrat = {
+        ic is c1
+      | ic is c3
+      | ic is c4
+      | ic is c5
+      | ic is c6
+      | ic is c8
+      | ic is m1
+      | ic is m3
+      | ic is m4
+      | ic is m5
+      | ic is m8
+      | ic is i1 ;
+      ComRat ic
+    } ;
+    empty =
+        ic is nc
+      | ic is nm
+  } ;
+
+  nbands = NBands irep ;
+
+  xbands = Choose {
+    def_xband = {
+      Guard (nbands == 0) ;
+      XBands nbands
+    } ;
+    no_xband = Guard (nbands != 0)
+  } ;
+
+  @num_bands =
+    { Guard (nbands != 0) ;
+      ^ nbands }
+  | { Guard (nbands == 0) ;
+      @bnds = xbands is def_xband ;
+      ^ bnds
+    } ;
+
+  bandinfo = Many (num_bands as! uint 64) {
+    irepbandn = IRepBandN ;
+    isubcatn = ISubCatN ;
+
+    IFCN ;
+    ImFltN ;
+
+    nlutsn = UpperBoundedDigit 4 ;
+
+    -- DOC: error message here could say more: thought that problem
+    -- was in how parser was used. Problem was actually buried in some
+    -- field of spaces.
+
+    -- check display params
+    DispParams irep irepbandn nbands pvtype nlutsn ;
+
+    Choose {
+      luts = {
+        Guard (nlutsn > 0) ;
+        nelutn = NELutN ;
+        lutd_nm = LutdNM nlutsn ;
+      } ;
+      no_luts = Guard (nlutsn == 0)
+    } 
+  } ;
+
+  ISync ;
+
+  imode = IMode nbands ;
+  nbpr = NBPR ;
+  -- TODO: rework to remove negations
+  nbpc = NBPC ;
+    (Guard (nbpr != 1) | Guard (nbpc != 1))
+  | (imode is blockMode | imode is pixel | imode is row);
+  -- is R really allowed? Needed by i_3201c.ntf.
+
+  nppbh = NPPBH ;
+  Guard (nbpr * nppbh >= n_cols) ;
+
+  nppbv = NPPBV ;
+  Guard (nbpc * nppbv >= n_rows) ;
+
+  nbpp = NBPP abpp ic ;
+
+  -- check all category-dependent parameters:
+  map
+    (bi in bandinfo)
+    (CatParams icat bi.isubcatn nbands pvtype nbpp abpp) ;
+
+  idlvl = IDLvl ;
+  ialvl = IALvl ;
+  iloc = Location ;
+  imag = IMag ;
+
+  udidl = UDIDL ;
+  Choose {
+    uds = {
+      Guard (udidl > 0) ;
+      udofl = UDOfl ;
+      udid = UDID udidl
+    } ;
+    empty = Guard (udidl == 0)
+  } ;
+
+  ixshdl = IXShDL ;
+  Choose {
+    ixs = {
+      Guard (ixshdl > 0) ;
+      ixsofl = IXSOfl ;
+      ixshd = IXShD ixshdl
+    } ;
+    empty = Guard (ixshdl == 0)
+  }
+}

--- a/nitf/nitf-modern/nitf_lib.ddl
+++ b/nitf/nitf-modern/nitf_lib.ddl
@@ -155,24 +155,24 @@ def Leq x y = (Eq x y) | (Lt x y)   -- XXX: Why not use <= ?
 
 def PartialEq (x : OrBytes) (y : OrBytes) =
   x is default
-| y is default
-| { @x0 = x is actual ;
+<| y is default
+<| { @x0 = x is actual ;
     @y0 = y is actual ;
     Eq x0 y0
   }
 
 def PartialLt (x : OrBytes) (y : OrBytes) =
   x is default
-| y is default
-| { @x0 = x is actual ;
+<| y is default
+<| { @x0 = x is actual ;
     @y0 = y is actual ;
     Lt x0 y0
   }
 
 def PartialLeq (x : OrBytes) (y : OrBytes) =
   x is default
-| y is default
-| { @x0 = x is actual ;
+<| y is default
+<| { @x0 = x is actual ;
     @y0 = y is actual ;
     Leq x0 y0
   }
@@ -247,18 +247,18 @@ def LiftDateTime (dt : DateTime) : PartialDateTime = {
 
 def PartialOrdDate (d0 : PartialDate) (d1 : PartialDate) =
   PartialLt d0.partCentury d1.partCentury
-| { PartialEq d0.partCentury d1.partCentury ;
+<| { PartialEq d0.partCentury d1.partCentury ;
       PartialLt d0.partYear d1.partYear
-    | { PartialEq d0.partYear d1.partYear ;
+    <| { PartialEq d0.partYear d1.partYear ;
           PartialLt d0.partMonth d1.partMonth
-        | { PartialEq d0.partMonth d1.partMonth ;
+        <| { PartialEq d0.partMonth d1.partMonth ;
             PartialLeq d0.partDay d1.partDay } } }
 
 def PartialOrdTime (t0 : PartialTime) (t1 : PartialTime) =
   PartialLt t0.partHour t1.partHour
-| { PartialEq t0.partHour t1.partHour ;
+<| { PartialEq t0.partHour t1.partHour ;
       PartialLt t0.partMin t1.partMin
-    | { PartialEq t0.partMin t1.partMin ;
+    <| { PartialEq t0.partMin t1.partMin ;
         PartialLeq t0.partSecond t1.partSecond } }
 
 def PartialOrdDateTime (dt0 : PartialDateTime) (dt1 : PartialDateTime) = {
@@ -286,7 +286,7 @@ def CountryCode = Many 2 AlphaNum
 
 -- ClSy: classification system
 def ClSy = DefaultSpaces 2 (
-  Choose {
+  Choose1 { -- NOTE-MODERN: explicitly `Choose1` to prevent overlapping
     nato = @Match "XN" ;
     country = CountryCode ;
   })

--- a/nitf/nitf-modern/nitf_lib.ddl
+++ b/nitf/nitf-modern/nitf_lib.ddl
@@ -274,7 +274,7 @@ def OrdDate (d0 : Date) (d1 : Date) = {
 }
 
 -- security classifications:
-def SecClas = Choose {
+def SecClas = Choose { -- NOTE-MODERN: non-overlapping
   topsecret = @Match1 'T' ;
   secret = @Match1 'S' ;
   confidential = @Match1 'C' ;
@@ -302,7 +302,7 @@ def CodeWords = DefaultSpaces 11 {
 }
 
 -- Security control markings: translated from Table A-4:
-def SecCtrlMarking = Choose {
+def SecCtrlMarking = Choose { -- NOTE-MODERN: non-overlapping, at least not on JITC
   atomal = @Match "AT" ;
   cndwdi = @Match "CN" ;
   copyright = @Match "PX" ;
@@ -341,7 +341,7 @@ def CtlHandling = DefaultSpaces 2 SecCtrlMarking
 
 def Release = Many 20 (UpperCase | Match1 ' ')
 
-def DeclassificationType = Choose {
+def DeclassificationType = Choose { -- NOTE-MODERN: non-overlapping
   date = @Match "DD" ;
   event = @Match "DE" ;
   datelv = @Match "GD" ;
@@ -353,7 +353,7 @@ def DeclassificationType = Choose {
 
 def Declassification = {
   dctp = DeclassificationType ;
-  dcdt = Choose {
+  dcdt = Choose { -- NOTE-MODERN: seams non-overlapping
     decldate = {
       -- TODO: cleanup parens
       (dctp is date | dctp is datelv) ;
@@ -368,7 +368,7 @@ def Declassification = {
       Spaces 8
     }
   } ;
-  dxcm = Choose {
+  dxcm = Choose { -- NOTE-MODERN: seams non-overlapping
     reason = {
       dctp is exempt ;
       Match1 'X' ;
@@ -389,12 +389,12 @@ def Declassification = {
       Spaces 4 ;
     }
   } ;
-  dg = Choose {
+  dg = Choose { -- NOTE-MODERN: seams non-overlapping
     actual = {
         dctp is datelv
       | dctp is eventlv ;
       DefaultSpace (
-        Choose {
+        Choose { -- NOTE-MODERN: non-overlapping
           secret = @Match1 'S' ;
           confidential = @Match1 'C' ;
           restricted = @Match1 'R' ;
@@ -409,7 +409,7 @@ def Declassification = {
       Spaces 1 ;
     }
   } ;
-  dgdt = Choose {
+  dgdt = Choose { -- NOTE-MODERN: seams non-overlapping
     hasdgdt = {
       dctp is datelv ;
       Date
@@ -424,7 +424,7 @@ def Declassification = {
       Spaces 8 ;
     }
   } ;
-  cltx = Choose {
+  cltx = Choose { -- NOTE-MODERN: seams non-overlapping
     hascltx = {
         dctp is datelv
       | dctp is eventlv ;
@@ -437,14 +437,14 @@ def Declassification = {
 -- authority type:
 def ClassificationAuthority = {
   authtp = DefaultSpace (
-    Choose {
+    Choose { -- NOTE-MODERN: non-overlapping
       original = @Match1 'O' ;
       derivative = @Match1 'D' ;
       multiple = @Match1 'M' ;
     }) ;
   auth = Many 40 ECSA ;
   crsn = DefaultSpace (
-    Choose {
+    Choose { -- NOTE-MODERN: non-overlapping
       clsrsnA = @Match1 'A' ;
       clsrsnB = @Match1 'B' ;
       clsrsnC = @Match1 'C' ;

--- a/nitf/nitf-modern/nitf_lib.ddl
+++ b/nitf/nitf-modern/nitf_lib.ddl
@@ -138,7 +138,7 @@ def DefaultByte D P = Choose {
 def DefaultSpace P = DefaultByte (Match1 ' ') P
 
 -- TODO: rename
-def OrBytes n b P = Choose {
+def OrBytes n b P = Choose1 { -- NOTE-MODERN: changed to `Choose1` to prevent multiple parses when overlapping
   actual = P ;
   default = @(Many n (Match b))
 }
@@ -353,7 +353,7 @@ def DeclassificationType = Choose { -- NOTE-MODERN: non-overlapping
 
 def Declassification = {
   dctp = DeclassificationType ;
-  dcdt = Choose { -- NOTE-MODERN: seams non-overlapping
+  dcdt = Choose { -- NOTE-MODERN: nonoverlapping
     decldate = {
       -- TODO: cleanup parens
       (dctp is date | dctp is datelv) ;
@@ -368,7 +368,7 @@ def Declassification = {
       Spaces 8
     }
   } ;
-  dxcm = Choose { -- NOTE-MODERN: seams non-overlapping
+  dxcm = Choose { -- NOTE-MODERN: nonoverlapping
     reason = {
       dctp is exempt ;
       Match1 'X' ;
@@ -389,12 +389,12 @@ def Declassification = {
       Spaces 4 ;
     }
   } ;
-  dg = Choose { -- NOTE-MODERN: seams non-overlapping
+  dg = Choose { -- NOTE-MODERN: nonoverlapping
     actual = {
         dctp is datelv
       | dctp is eventlv ;
       DefaultSpace (
-        Choose { -- NOTE-MODERN: non-overlapping
+        Choose { -- NOTE-MODERN: nonoverlapping
           secret = @Match1 'S' ;
           confidential = @Match1 'C' ;
           restricted = @Match1 'R' ;
@@ -409,7 +409,7 @@ def Declassification = {
       Spaces 1 ;
     }
   } ;
-  dgdt = Choose { -- NOTE-MODERN: seams non-overlapping
+  dgdt = Choose { -- NOTE-MODERN: nonoverlapping
     hasdgdt = {
       dctp is datelv ;
       Date
@@ -424,7 +424,7 @@ def Declassification = {
       Spaces 8 ;
     }
   } ;
-  cltx = Choose { -- NOTE-MODERN: seams non-overlapping
+  cltx = Choose1 { -- NOTE-MODERN: fixed to `Choose1` bc overlapping on SPACE char
     hascltx = {
         dctp is datelv
       | dctp is eventlv ;
@@ -437,14 +437,14 @@ def Declassification = {
 -- authority type:
 def ClassificationAuthority = {
   authtp = DefaultSpace (
-    Choose { -- NOTE-MODERN: non-overlapping
+    Choose { -- NOTE-MODERN: nonoverlapping
       original = @Match1 'O' ;
       derivative = @Match1 'D' ;
       multiple = @Match1 'M' ;
     }) ;
   auth = Many 40 ECSA ;
   crsn = DefaultSpace (
-    Choose { -- NOTE-MODERN: non-overlapping
+    Choose { -- NOTE-MODERN: nonoverlapping
       clsrsnA = @Match1 'A' ;
       clsrsnB = @Match1 'B' ;
       clsrsnC = @Match1 'C' ;

--- a/nitf/nitf-modern/nitf_lib.ddl
+++ b/nitf/nitf-modern/nitf_lib.ddl
@@ -1,0 +1,481 @@
+-- Combinator to run a parser on a fixed-size chunk
+
+def Chunk n P =  {
+  @cur  = GetStream;
+  @this = Take n cur;
+  @next = Drop n cur;
+  SetStream this;
+  $$ = P;
+  SetStream next;
+}
+
+-- A parser that succeeds only if the predicate is true.
+def Guard p = p is true
+
+-- library of parsers that are generally useful for NITF
+
+def numBase (base : uint 64) (ds : [ uint 8 ]) =
+  for (val = 0; d in ds)
+    (val * base + (d as uint 64))
+
+-- def strlen s = for (len = (0 : int); c in s) (len + 1)
+
+-- parsers:
+
+-- Force the parser to backtrack
+def MyFail = { Choose {}; }
+
+def Etx = Match1 4
+
+{-- Character sets --}
+
+-- BCS character set
+def BCS = Match1 (0x20 .. 0x7E | 0x0C | 0x0D)
+def BCSA = Match1 (0x20 .. 0x7E )
+def BCSN = Match1 (0x30 .. 0x39 | 0x2B | 0x2D )
+
+-- ECS character set
+-- TODO: work out error handling if deprecated ECS codes are used
+def ECS = BCS
+def ECSA = BCSA
+
+def LowerCase = Match1 ('a' .. 'z')
+
+def UpperCase = Match1 ('A' .. 'Z')
+
+def Alpha = UpperCase | LowerCase
+
+def Numeral = Match1 ('0' .. '9')
+
+def Sign = Match1 ('+' | '-')
+
+def Digit = { @d = Numeral ; ^ d - '0' }
+
+def FixedPoint = {
+  digs = Many Digit ;
+  Match1 '.' ;
+  radix = Many Digit
+}
+
+def UnsignedNum digs = {
+  @ds = Many digs Digit ;
+  ^ for (val = 0; d in ds)
+        (val * 10 + (d as uint 64))
+--  ^ numBase 10 ds
+}
+
+def NegNum digs = {
+  Match1 '-' ;
+  @n = UnsignedNum digs ;
+  ^ 0 - n
+}
+
+def SignedNum digs = Choose {
+  pos = UnsignedNum (digs + 1) ;
+  neg = NegNum digs
+}
+
+def BoundedNum digs lb ub = {
+  $$ = UnsignedNum digs;
+  Guard (lb <= $$) ;
+  Guard ($$ <= ub)
+}
+
+def PosNumber digs = {
+  $$ = UnsignedNum digs;
+  Guard (1 <= $$)
+}
+
+def IsNum digs v = BoundedNum digs v v
+
+-- DOC: why can't the above bounds check be refactored?
+
+def BoundedDigit lb ub = BoundedNum 1 lb ub
+
+def UpperBoundedDigit ub = BoundedDigit 0 ub as! uint 64
+
+def BoundedPos digs ub = BoundedNum digs 1 ub
+
+def UpperBounded digs ub = BoundedNum digs 0 ub
+
+def PosQuad = BoundedNum 4 1 9999
+
+def LowerBoundedOrZero digs lb = {
+  $$ = UnsignedNum digs;
+  Guard ($$ == 0) | Guard (lb <= $$)
+}
+
+def Pos = Match1 ('1' .. '9')
+
+def AlphaNum = Alpha | Numeral
+
+-- TODO: replace with specific BCS classes
+def Byte = Match1 (0 .. 255)
+
+def Spaces (n : uint 64) = Many n (Match1 ' ')
+
+-- def PadWSpaces n P =
+--   Chunk n {$$ = P; Many (Match1 ' '); END}
+
+-- useful for when arr is statically known
+-- def padArray n pad arr =
+--     concat [ arr, map (x in rangeUp 1 (n - length arr)) pad ]
+
+def PadMatch n pad arr =
+  { @Match arr; @Many (n - length arr) (Match1 pad) }
+
+-- FIXME: this assumes P consumes exactly 1 char
+def PadMany n pad P =
+    block
+      $$ = Many (..n) P
+      Many (n - length $$) (Match1 pad)
+
+def DefaultByte D P = Choose {
+  actual = P ;
+  default = @D ;
+}
+
+def DefaultSpace P = DefaultByte (Match1 ' ') P
+
+-- TODO: rename
+def OrBytes n b P = Choose {
+  actual = P ;
+  default = @(Many n (Match b))
+}
+
+def DefaultSpaces n P = OrBytes n " " P
+
+def OrHyphens n P = OrBytes n "-" P
+
+def Eq x y = Guard (x == y)
+
+def Lt x y = Guard (x < y)
+
+def Leq x y = (Eq x y) | (Lt x y)   -- XXX: Why not use <= ?
+
+def PartialEq (x : OrBytes) (y : OrBytes) =
+  x is default
+| y is default
+| { @x0 = x is actual ;
+    @y0 = y is actual ;
+    Eq x0 y0
+  }
+
+def PartialLt (x : OrBytes) (y : OrBytes) =
+  x is default
+| y is default
+| { @x0 = x is actual ;
+    @y0 = y is actual ;
+    Lt x0 y0
+  }
+
+def PartialLeq (x : OrBytes) (y : OrBytes) =
+  x is default
+| y is default
+| { @x0 = x is actual ;
+    @y0 = y is actual ;
+    Leq x0 y0
+  }
+
+def Date = {
+  century = UnsignedNum 2 ;
+  year = UnsignedNum 2 ;
+  month = BoundedPos 2 12 ;
+  day = BoundedPos 2 31
+}
+
+def Epoch : Date = {
+  century = ^ 19 ;
+  year = ^ 70 ;
+  month = ^ 1 ;
+  day = ^ 1
+}
+
+def Today : Date = {
+  century = ^ 20 ;
+  year = ^ 20 ;
+  month = ^ 5 ;
+  day = ^ 22
+}
+
+def Time = {
+  hour = UpperBounded 2 23 ;
+  min = UpperBounded 2 59 ;
+  second = UpperBounded 2 59
+}
+
+def DateTime = {
+  date = Date ;
+  time = Time
+}
+
+def PartialDate = {
+  partCentury = OrHyphens 2 (UnsignedNum 2) ;
+  partYear = OrHyphens 2 (UnsignedNum 2) ;
+  partMonth = OrHyphens 2 (BoundedPos 2 12) ;
+  partDay = OrHyphens 2 (BoundedPos 2 31)
+}
+
+def LiftDate (d : Date) : PartialDate = {
+  partCentury = ^ {| actual = d.century |} ;
+  partYear = ^ {| actual = d.year |} ;
+  partMonth = ^ {| actual = d.month |} ;
+  partDay = ^ {| actual = d.day |}
+}
+
+def PartialTime = {
+  partHour = OrHyphens 2 (UpperBounded 2 23) ;
+  partMin = OrHyphens 2 (UpperBounded 2 59) ;
+  partSecond = OrHyphens 2 (UpperBounded 2 59)
+}
+
+def LiftTime (t : Time) : PartialTime = {
+  partHour = ^ {| actual = t.hour |} ;
+  partMin = ^ {| actual = t.min |} ;
+  partSecond = ^ {| actual = t.second |}
+}
+
+def PartialDateTime = {
+  partDate = PartialDate ;
+  partTime = PartialTime
+}
+
+def LiftDateTime (dt : DateTime) : PartialDateTime = {
+  partDate = LiftDate dt.date ;
+  partTime = LiftTime dt.time
+}
+
+def PartialOrdDate (d0 : PartialDate) (d1 : PartialDate) =
+  PartialLt d0.partCentury d1.partCentury
+| { PartialEq d0.partCentury d1.partCentury ;
+      PartialLt d0.partYear d1.partYear
+    | { PartialEq d0.partYear d1.partYear ;
+          PartialLt d0.partMonth d1.partMonth
+        | { PartialEq d0.partMonth d1.partMonth ;
+            PartialLeq d0.partDay d1.partDay } } }
+
+def PartialOrdTime (t0 : PartialTime) (t1 : PartialTime) =
+  PartialLt t0.partHour t1.partHour
+| { PartialEq t0.partHour t1.partHour ;
+      PartialLt t0.partMin t1.partMin
+    | { PartialEq t0.partMin t1.partMin ;
+        PartialLeq t0.partSecond t1.partSecond } }
+
+def PartialOrdDateTime (dt0 : PartialDateTime) (dt1 : PartialDateTime) = {
+  PartialOrdDate dt0.partDate dt1.partDate ;
+  PartialOrdTime dt0.partTime dt1.partTime
+}
+
+-- OrdDate: check that two dates are ordered
+def OrdDate (d0 : Date) (d1 : Date) = {
+  @d0val = LiftDate d0 ;
+  @d1val = LiftDate d1 ;
+  PartialOrdDate d0val d1val
+}
+
+-- security classifications:
+def SecClas = Choose {
+  topsecret = @Match1 'T' ;
+  secret = @Match1 'S' ;
+  confidential = @Match1 'C' ;
+  restricted = @Match1 'R' ;
+  unclassified = @Match1 'U' ;
+}
+
+def CountryCode = Many 2 AlphaNum
+
+-- ClSy: classification system
+def ClSy = DefaultSpaces 2 (
+  Choose {
+    nato = @Match "XN" ;
+    country = CountryCode ;
+  })
+
+-- CodeWords: a space-separated sequence of codewords
+def CodeWords = DefaultSpaces 11 {
+  first = SecCtrlMarking ;
+  rest = Many (..3) {
+    Match1 ' ' ;
+    SecCtrlMarking
+  } ;
+  Spaces (11 - (2 + 3 * length rest))
+}
+
+-- Security control markings: translated from Table A-4:
+def SecCtrlMarking = Choose {
+  atomal = @Match "AT" ;
+  cndwdi = @Match "CN" ;
+  copyright = @Match "PX" ;
+  cosmic = @Match "CS" ;
+  crypto = @Match "CR" ;
+  efto = @Match "TX" ;
+  formrestData = @Match "RF" ;
+  fouo = @Match "FO" ;
+  generalService = @Match "GS" ;
+  limOffUse = @Match "LU" ;
+  limdis = @Match "DS" ;
+  nato = @Match "NS" ;
+  noContract = @Match "NC" ;
+  noncompartment = @Match "NT" ;
+  orcon = @Match "OR" ;
+  personalData = @Match "IN" ;
+  propin = @Match "PI" ;
+  restrictedData = @Match "RD" ;
+  sao = @Match "SA" ;
+  sao1 = @Match "SL" ;
+  sao2 = @Match "HA" ;
+  sao3 = @Match "HB" ;
+  saoSi2 = @Match "SK" ;
+  saoSi3 = @Match "HC" ;
+  saoSi4 = @Match "HD" ;
+  siop = @Match "SH" ;
+  siopEsi = @Match "SE" ;
+  specialControl = @Match "SC" ;
+  specialIntel = @Match "SI" ;
+  usOnly = @Match "UO" ;
+  warningNotice = @Match "WN" ;
+  wnintel = @Match "WI" ;
+}
+
+def CtlHandling = DefaultSpaces 2 SecCtrlMarking
+
+def Release = Many 20 (UpperCase | Match1 ' ')
+
+def DeclassificationType = Choose {
+  date = @Match "DD" ;
+  event = @Match "DE" ;
+  datelv = @Match "GD" ;
+  eventlv = @Match "GE" ;
+  oadr = @Match "O " ;
+  exempt = @Match "X " ;
+  none = @(Spaces 2)
+}
+
+def Declassification = {
+  dctp = DeclassificationType ;
+  dcdt = Choose {
+    decldate = {
+      -- TODO: cleanup parens
+      (dctp is date | dctp is datelv) ;
+      Date
+    } ;
+    nodate = {
+      ( dctp is event
+      | dctp is eventlv
+      | dctp is oadr
+      | dctp is exempt
+      | dctp is none) ;
+      Spaces 8
+    }
+  } ;
+  dxcm = Choose {
+    reason = {
+      dctp is exempt ;
+      Match1 'X' ;
+      $$ = PadMany 3 ' ' Digit;
+      @v = ^ for (val = 0; d in $$)
+                 (val * 10 + (d as uint 64));
+		 -- (numBase 10 $$) ;
+        { Guard (1   <= v); Guard (v <= 8)   }
+      | { Guard (251 <= v); Guard (v <= 259) }
+    } ;
+    notexempt = @{
+        dctp is date
+      | dctp is event
+      | dctp is datelv
+      | dctp is eventlv
+      | dctp is oadr
+      | dctp is none ;
+      Spaces 4 ;
+    }
+  } ;
+  dg = Choose {
+    actual = {
+        dctp is datelv
+      | dctp is eventlv ;
+      DefaultSpace (
+        Choose {
+          secret = @Match1 'S' ;
+          confidential = @Match1 'C' ;
+          restricted = @Match1 'R' ;
+        })
+    } ;
+    none = @{
+        dctp is date
+      | dctp is event
+      | dctp is oadr
+      | dctp is exempt
+      | dctp is none ;
+      Spaces 1 ;
+    }
+  } ;
+  dgdt = Choose {
+    hasdgdt = {
+      dctp is datelv ;
+      Date
+    } ;
+    nodgdt = @{
+        dctp is date
+      | dctp is event
+      | dctp is eventlv
+      | dctp is oadr
+      | dctp is exempt
+      | dctp is none ;
+      Spaces 8 ;
+    }
+  } ;
+  cltx = Choose {
+    hascltx = {
+        dctp is datelv
+      | dctp is eventlv ;
+      Many 43 ECSA
+    } ;
+    nocltx = Spaces 43 ;
+  }
+}
+
+-- authority type:
+def ClassificationAuthority = {
+  authtp = DefaultSpace (
+    Choose {
+      original = @Match1 'O' ;
+      derivative = @Match1 'D' ;
+      multiple = @Match1 'M' ;
+    }) ;
+  auth = Many 40 ECSA ;
+  crsn = DefaultSpace (
+    Choose {
+      clsrsnA = @Match1 'A' ;
+      clsrsnB = @Match1 'B' ;
+      clsrsnC = @Match1 'C' ;
+      clsrsnD = @Match1 'D' ;
+      clsrsnE = @Match1 'E' ;
+      clsrsnF = @Match1 'F' ;
+      clsrsnG = @Match1 'G' ;
+    })
+}
+
+def Security = {
+  srdt = DefaultSpaces 8 Date ;
+  ctln = DefaultSpaces 15 (Many 15 Digit)
+}
+
+def CommonSubheader = {
+  clas = SecClas ;
+  clsy = ClSy ;
+  code = CodeWords ;
+  ctlh = CtlHandling ;
+  rel = Release ;
+  decl = Declassification ;
+  clauth = ClassificationAuthority ;
+  sec = Security
+}
+
+def Encryp = Match1 '0'
+
+def AttachmentLvl = UpperBounded 3 998
+
+def Location = {
+  row = SignedNum 4 ;
+  col = SignedNum 4
+}

--- a/nitf/nitf-modern/nitf_main.ddl
+++ b/nitf/nitf-modern/nitf_main.ddl
@@ -1,0 +1,78 @@
+import nitf_lib
+import nitf_header 
+import nitf_img_subheader
+import nitf_graphic_subheader
+import nitf_text_subheader
+import nitf_data_ext_subheader
+import nitf_res_ext_subheader
+
+def CheckDateTime fdt dt = @{
+   @ep = Epoch ;
+   @lep = LiftDate ep ;
+   -- check that the image was created after Epoch
+   PartialOrdDate lep dt.partDate ;
+
+   -- check that the image was created before today
+   @today = Today ;
+   @ltoday = LiftDate today ;
+   PartialOrdDate dt.partDate ltoday ;
+
+   -- check that the data was created before the file
+   PartialOrdDateTime dt fdt ;
+}
+
+def Main = { 
+    h = Header;
+    @ldt = LiftDateTime h.fdt ;
+
+    -- parse each image segment:
+    img_segments = 
+      map (imglens in h.li) { 
+        imgHeader = ISHeader ;
+        CheckDateTime ldt imgHeader.idatim ;
+
+        -- parse the bytes in the data segment
+        -- imgData = Many imglens.li Byte ;
+      };
+    
+    -- parse each graphic segment:
+    graph_segments = 
+      map (gls in h.graphlens) {  
+        graphHeader = GraphicHeader ;
+
+        -- parse the bytes in the data segment
+        graphData = Many (gls.seglen as! uint 64) Byte ;
+      } ; 
+
+    -- parse each text segment:
+    txt_segments = 
+      map (textls in h.textlens) {
+        txtHeader = TextHeader ;
+
+        CheckDateTime ldt txtHeader.txtdt ;
+
+        -- parse the bytes in the data segment
+        txtData = Many (textls.lt as! uint 64) Byte ;
+      };
+
+    -- parse each data-extension segment:
+    dataExt_segments = 
+      map (dataextls in h.dataextlens) {
+        dataExtHeader = DataExtHeader ;
+
+        -- parse the bytes in the data extension data segment
+        dataExtData = Many (dataextls.ld as! uint 64) Byte ;
+      } ;
+
+    -- parse each reserved-extension segment:
+    reservedExt_segments = 
+      map (resextls in h.resextlens) { 
+        resExtHeader = ResExtHeader ;
+
+        -- parse the bytes in the reserved extension data segment
+        resExtData = Many (resextls.lre as! uint 64) Byte ;
+      } ;
+
+    -- TEST: enable to fail JITC Neg Format cases
+    -- END;
+} 

--- a/nitf/nitf-modern/nitf_main.ddl
+++ b/nitf/nitf-modern/nitf_main.ddl
@@ -1,5 +1,5 @@
 import nitf_lib
-import nitf_header 
+import nitf_header
 import nitf_img_subheader
 import nitf_graphic_subheader
 import nitf_text_subheader
@@ -21,31 +21,31 @@ def CheckDateTime fdt dt = @{
    PartialOrdDateTime dt fdt ;
 }
 
-def Main = { 
+def Main = {
     h = Header;
     @ldt = LiftDateTime h.fdt ;
 
     -- parse each image segment:
-    img_segments = 
-      map (imglens in h.li) { 
+    img_segments =
+      map (imglens in h.li) {
         imgHeader = ISHeader ;
         CheckDateTime ldt imgHeader.idatim ;
 
         -- parse the bytes in the data segment
         -- imgData = Many imglens.li Byte ;
       };
-    
+
     -- parse each graphic segment:
-    graph_segments = 
-      map (gls in h.graphlens) {  
+    graph_segments =
+      map (gls in h.graphlens) {
         graphHeader = GraphicHeader ;
 
         -- parse the bytes in the data segment
         graphData = Many (gls.seglen as! uint 64) Byte ;
-      } ; 
+      } ;
 
     -- parse each text segment:
-    txt_segments = 
+    txt_segments =
       map (textls in h.textlens) {
         txtHeader = TextHeader ;
 
@@ -56,7 +56,7 @@ def Main = {
       };
 
     -- parse each data-extension segment:
-    dataExt_segments = 
+    dataExt_segments =
       map (dataextls in h.dataextlens) {
         dataExtHeader = DataExtHeader ;
 
@@ -65,8 +65,8 @@ def Main = {
       } ;
 
     -- parse each reserved-extension segment:
-    reservedExt_segments = 
-      map (resextls in h.resextlens) { 
+    reservedExt_segments =
+      map (resextls in h.resextlens) {
         resExtHeader = ResExtHeader ;
 
         -- parse the bytes in the reserved extension data segment
@@ -75,4 +75,4 @@ def Main = {
 
     -- TEST: enable to fail JITC Neg Format cases
     -- END;
-} 
+}

--- a/nitf/nitf-modern/nitf_res_ext_subheader.ddl
+++ b/nitf/nitf-modern/nitf_res_ext_subheader.ddl
@@ -12,7 +12,7 @@ def ResExtHeader = {
   resshl = UnsignedNum 4 as? uint 64;
   resshf = Many resshl BCSA ;
 
-  Many Byte 
+  Many Byte
 
   -- TODO: refactor above fields into lib
 }

--- a/nitf/nitf-modern/nitf_res_ext_subheader.ddl
+++ b/nitf/nitf-modern/nitf_res_ext_subheader.ddl
@@ -1,0 +1,18 @@
+import nitf_lib
+
+def ResExtHeader = {
+  Match "RE" ;
+  resid = Many 25 BCSA ;
+  resver = PosNumber 2 ;
+
+  common = CommonSubheader ;
+
+  -- TODO: implement validation in note on p125
+
+  resshl = UnsignedNum 4 as? uint 64;
+  resshf = Many resshl BCSA ;
+
+  Many Byte 
+
+  -- TODO: refactor above fields into lib
+}

--- a/nitf/nitf-modern/nitf_text_subheader.ddl
+++ b/nitf/nitf-modern/nitf_text_subheader.ddl
@@ -15,7 +15,7 @@ def TxtFmt = Choose {
 
 def TxShDL =
   (IsNum 5 0)
-| (BoundedNum 5 3 9717)
+| (BoundedNum 5 3 9717) -- NOTE-MODERN: nonoverlapping
 
 def TextHeader = {
   TE ;
@@ -32,7 +32,7 @@ def TextHeader = {
 
   txshdl = TxShDL as! uint 64;
 
-  Choose { -- NOTE-MODERN: seems overlapping but not harmful
+  Choose { -- NOTE-MODERN: seems overlapping but apparently not harmful
     txsofl = {
       UnsignedNum 3 ;
     } ;

--- a/nitf/nitf-modern/nitf_text_subheader.ddl
+++ b/nitf/nitf-modern/nitf_text_subheader.ddl
@@ -32,7 +32,7 @@ def TextHeader = {
 
   txshdl = TxShDL as! uint 64;
 
-  Choose {
+  Choose { -- NOTE-MODERN: seems overlapping but not harmful
     txsofl = {
       UnsignedNum 3 ;
     } ;

--- a/nitf/nitf-modern/nitf_text_subheader.ddl
+++ b/nitf/nitf-modern/nitf_text_subheader.ddl
@@ -1,0 +1,43 @@
+import nitf_lib
+
+def TE = Match "TE"
+
+def TextId = Many 7 (AlphaNum | Match1 ' ')
+
+def TxTitl = Many 80 ECSA
+
+def TxtFmt = Choose {
+  usmtf = @Match "MTF" ;
+  bcs = @Match "STA" ;
+  ecs = @Match "UT1" ;
+  u8s = @Match "U8S" ;
+}
+
+def TxShDL =
+  (IsNum 5 0)
+| (BoundedNum 5 3 9717)
+
+def TextHeader = {
+  TE ;
+  textid = TextId ;
+  txtalvl = AttachmentLvl ;
+  txtdt = PartialDateTime ;
+  txtitl = TxTitl ;
+
+  common = CommonSubheader ;
+
+  Encryp ;
+
+  txtfmt = TxtFmt ;
+
+  txshdl = TxShDL as! uint 64;
+
+  Choose {
+    txsofl = {
+      UnsignedNum 3 ;
+    } ;
+    omitted = Guard (txshdl == 0);
+  } ;
+
+  txshd = Many (txshdl - 3) BCSA ;
+}

--- a/nitf/nitf_header.ddl
+++ b/nitf/nitf_header.ddl
@@ -1,75 +1,75 @@
 import nitf_lib
 
--- Wrap a value in a Maybe 
+-- Wrap a value in a Maybe
 
 def CallMeMaybe P = { @r = P; ^ just r}
 
-{-- Field parsers --} 
+{-- Field parsers --}
 
-def FHDR = Match "NITF" 
+def FHDR = Match "NITF"
 
-def FVER = Match "02.10" 
+def FVER = Match "02.10"
 
--- Valid values 01 .. 99 
-def CLEVEL ={ 
-  @l = UnsignedNum 2; 
-  Guard (l != 0); 
-  ^l; 
+-- Valid values 01 .. 99
+def CLEVEL ={
+  @l = UnsignedNum 2;
+  Guard (l != 0);
+  ^l;
 }
 
-def STYPE = Match "BF01" 
+def STYPE = Match "BF01"
 
-def OSTAID = Choose1 { 
+def OSTAID = Choose1 {
   { Match "0000000000"; MyFail};  -- ill-formed
-  Many 10 BCSA; 
+  Many 10 BCSA;
 }
 
 def FDT = DateTime
 
-def FTITLE = Many 80 ECSA 
+def FTITLE = Many 80 ECSA
 
 def FSCLAS = Match1 ('T' | 'S' | 'C' | 'R' | 'U')
 
 def Digraph = Many (1..) (Match1 ('A'..'Z'))
 
--- TODO: Field must contain valid codes per FIPS PUB 10-4, "XN", or "  "   
--- TODO: Field must be set if any of the following are set: FSCODE, 
---       FSREL, FSDCTP, FSDCDT, FSDCXM, FSDG, FSDGDT, FSCLTX, FSCATP, 
+-- TODO: Field must contain valid codes per FIPS PUB 10-4, "XN", or "  "
+-- TODO: Field must be set if any of the following are set: FSCODE,
+--       FSREL, FSDCTP, FSDCDT, FSDCXM, FSDG, FSDGDT, FSCLTX, FSCATP,
 --       FSCAUT, FSCRSN, FSSRDT, and FSCTLN
-def FSCLSY = Digraph | Match "  " 
+def FSCLSY = Digraph | Match "  "
 
-def DigraphSeq = Choose1 { 
-  { @d = Digraph; 
-    @ds = Many { Match1 ' '; $$ = Digraph}; 
-    Many (Match1 ' '); 
-    END; 
-    ^ just (concat [ [d], ds ]) }; 
-  {Many (Match1 ' '); END; ^ nothing}; 
-} 
+def DigraphSeq = Choose1 {
+  { @d = Digraph;
+    @ds = Many { Match1 ' '; $$ = Digraph};
+    Many (Match1 ' ');
+    END;
+    ^ just (concat [ [d], ds ]) };
+  {Many (Match1 ' '); END; ^ nothing};
+}
 
-def FSCODE = Chunk 11 DigraphSeq 
+def FSCODE = Chunk 11 DigraphSeq
 
-def FSCTLH = Digraph | Match "  " 
+def FSCTLH = Digraph | Match "  "
 
-def FSREL = Choose1 { 
+def FSREL = Choose1 {
   Chunk 20 DigraphSeq
 }
 
--- Unclear how to pad single characters here... 
-def FSDCTP = Choose { 
-  dd = Match "DD" ; 
-  de = Match "DE" ; 
-  gd = Match "GD" ; 
-  ge = Match "GE" ; 
-  o = Match "O " ; 
-  x = Match "X " ; 
-  none = Match "  " ; 
-} 
+-- Unclear how to pad single characters here...
+def FSDCTP = Choose {
+  dd = Match "DD" ;
+  de = Match "DE" ;
+  gd = Match "GD" ;
+  ge = Match "GE" ;
+  o = Match "O " ;
+  x = Match "X " ;
+  none = Match "  " ;
+}
 
--- TODO Add proper date parsing 
-def Date2 = Many 8 ECSA 
+-- TODO Add proper date parsing
+def Date2 = Many 8 ECSA
 
--- padding again 
+-- padding again
 def FSDCXM =
   [ Match1 ' '; Match1 ' '; Match1 'X'; Match1 ('1' .. '8') ] |
   [ Match1 'X'; Match1 ('1' .. '8'); Match1 ' '; Match1 ' ' ] |
@@ -77,76 +77,76 @@ def FSDCXM =
 
 def FSDG = Match1 ('S' | 'C' | 'R')
 
-def FSDGDT = Many 8 ECSA 
+def FSDGDT = Many 8 ECSA
 
-def FSCLTX = Many 43 ECSA 
+def FSCLTX = Many 43 ECSA
 
-def FS_declass = { 
-  declass_type = FSDCTP; 
+def FS_declass = {
+  declass_type = FSDCTP;
   fsdcdt = Choose1 {
-    { declass_type is dd; CallMeMaybe Date2 }; 
-    { Many 8 (Match1 ' '); ^ nothing }; 
+    { declass_type is dd; CallMeMaybe Date2 };
+    { Many 8 (Match1 ' '); ^ nothing };
   };
-  fsdcxm = Choose1 { 
-    { declass_type is x; @f = FSDCXM; ^ just f}; 
-    { Many 4 (Match1 ' '); ^ nothing }; 
-  }; 
-  fsdg = Choose1 { 
-    { declass_type is gd | declass_type is ge; 
+  fsdcxm = Choose1 {
+    { declass_type is x; @f = FSDCXM; ^ just f};
+    { Many 4 (Match1 ' '); ^ nothing };
+  };
+  fsdg = Choose1 {
+    { declass_type is gd | declass_type is ge;
       @f = FSDG; ^ just f};
-    { Match1 ' '; ^ nothing }; 
-  }; 
-  fsdgdt = Choose1 { 
-    { declass_type is gd; @d = Date2; ^ just d}; 
-    { Many 8 (Match1 ' '); ^ nothing}; 
+    { Match1 ' '; ^ nothing };
   };
-  fscltx = Choose1 { 
-    { declass_type is de | declass_type is ge; 
-      CallMeMaybe (@Many 43 ECSA) }; 
-    { Many 43 (Match1 ' '); ^ nothing} 
+  fsdgdt = Choose1 {
+    { declass_type is gd; @d = Date2; ^ just d};
+    { Many 8 (Match1 ' '); ^ nothing};
+  };
+  fscltx = Choose1 {
+    { declass_type is de | declass_type is ge;
+      CallMeMaybe (@Many 43 ECSA) };
+    { Many 43 (Match1 ' '); ^ nothing}
   }
-} 
+}
 
-def FSC_auth = Choose1 { 
-  { CallMeMaybe { 
+def FSC_auth = Choose1 {
+  { CallMeMaybe {
       type = Match1 ('O' | 'D' | 'M');
-      auth = Many 40 ECSA; 
+      auth = Many 40 ECSA;
     }
-  };  
-  { Match1 ' '; Many 40 ECSA; ^ nothing}; 
-} 
+  };
+  { Match1 ' '; Many 40 ECSA; ^ nothing};
+}
 
 def FSCRSN = Match1 ('A' .. 'G' | ' ')
 
-def FSSRDT = Many 8 ECSA 
- 
-def FSCTLN = Many 15 ECSA 
+def FSSRDT = Many 8 ECSA
+
+def FSCTLN = Many 15 ECSA
 
 def FSCOP = Many 5 BCSN
 
 def FSCPYS = Many 5 BCSN
 
-def ENCRYP = BCSN 
+def ENCRYP = BCSN
 
--- The nonstandard_utf8 case is a magic sequence that isn't defined in the 
+-- The nonstandard_utf8 case is a magic sequence that isn't defined in the
 -- NITF standard, but is handled in the Hammer parser
-def FBKGC = 
-  Choose1 { 
+def FBKGC =
+  Choose1 {
     nonstandard_utf8 = Many 3 {Match [0xef; 0xbf; 0xbd]; ^ 0xbd} : [uint 8]; -- XXX: This seems wrong.
     normal = Many 3 (Match1 (0x00 .. 0xFF));
-  } 
+  }
 
-def ONAME = Many 24 ECSA 
+def ONAME = Many 24 ECSA
 
-def OPHONE = Many 18 ECSA 
+def OPHONE = Many 18 ECSA
 
-def FL = Choose1 { 
-  unknown_length = Many 12 (Match1 '9');  
+def FL = Choose1 {
+  unknown_length = Many 12 (Match1 '9');
   -- TODO put interval bounds here:
-  file_length = UnsignedNum 12 ; 
-} 
+  file_length = UnsignedNum 12 ;
+}
 
-def HL = UnsignedNum 6 
+def HL = UnsignedNum 6
 
 -- TODO: refactor this into code that computes max for some number of UnsignedNums
 
@@ -161,10 +161,10 @@ def GraphLens = {
   seglen = BoundedPos 6 999999
 }
 
-def NUMX = Match "000" 
+def NUMX = Match "000"
 
-def LTSH = Many 4 BCSN 
-def LT = Many 5 BCSN 
+def LTSH = Many 4 BCSN
+def LT = Many 5 BCSN
 
 def TextLens = {
   ltsh = BoundedNum 4 282 9999 ;
@@ -176,30 +176,30 @@ def DataExtLens = {
   ld = BoundedPos 9 999999999
 }
 
-def LRESH = Many 4 BCSN 
-def LRE = Many 7 BCSN 
+def LRESH = Many 4 BCSN
+def LRE = Many 7 BCSN
 
 def ResExtLens = {
   lresh = BoundedNum 4 200 9999 ;
   lre = BoundedPos 7 9999999
 }
 
-def UDHDL = Many 5 BCSN 
+def UDHDL = Many 5 BCSN
 
-def UserData = Choose1 { 
-                 none = { Match "00000"; ^ {} } ; 
+def UserData = Choose1 {
+                 none = { Match "00000"; ^ {} } ;
                  udhd = {@l = UnsignedNum 5 as! uint 64;
-                         overflow = Many 3 BCSN; 
-                         data = Many (l - 3) UInt8; }; 
-               } 
+                         overflow = Many 3 BCSN;
+                         data = Many (l - 3) UInt8; };
+               }
 
 
 {-- Main header parser --}
 
-def Header = { 
-  FHDR; 
+def Header = {
+  FHDR;
   fver = FVER;
-  clevel = CLEVEL; 
+  clevel = CLEVEL;
   STYPE;
   ostaid = OSTAID;
   fdt = FDT;
@@ -213,27 +213,27 @@ def Header = {
   OrdDate fdt.date today ;
 
   ftitle = FTITLE;
-  fsclas = FSCLAS; 
-  fsclsy = FSCLSY; 
-  fscode = FSCODE;  
-  fsctlh = FSCTLH; 
-  fsrel = FSREL; 
-  
-  fs_declass = FS_declass; 
+  fsclas = FSCLAS;
+  fsclsy = FSCLSY;
+  fscode = FSCODE;
+  fsctlh = FSCTLH;
+  fsrel = FSREL;
 
-  fsc_auth = FSC_auth; 
+  fs_declass = FS_declass;
 
-  fscrsn = FSCRSN; 
-  fssrdt = FSSRDT; 
+  fsc_auth = FSC_auth;
+
+  fscrsn = FSCRSN;
+  fssrdt = FSSRDT;
   fsctln = FSCTLN;
-  fscop = FSCOP; 
-  fscpys = FSCPYS; 
-  encryp = ENCRYP; 
+  fscop = FSCOP;
+  fscpys = FSCPYS;
+  encryp = ENCRYP;
   fbkgc = FBKGC;
-  oname = ONAME; 
-  ophone = OPHONE; 
-  fl = FL; 
-  hl = HL; 
+  oname = ONAME;
+  ophone = OPHONE;
+  fl = FL;
+  hl = HL;
 
   numi = UnsignedNum 3 ;
   li = Many (numi as! uint 64) ImgLens ;
@@ -241,7 +241,7 @@ def Header = {
   nums = UnsignedNum 3 ;
   graphlens = Many (nums as! uint 64) GraphLens ;
 
-  NUMX; 
+  NUMX;
   @numt = UnsignedNum 3 ;
   textlens = Many (numt as! uint 64) TextLens ;
 
@@ -252,7 +252,7 @@ def Header = {
   resextlens = Many (numres as! uint 64) ResExtLens ;
 
   lre = Many (numres as! uint 64) [LRESH; LRE];
-  
+
   udhd = UserData;
-  xhd = UserData; 
+  xhd = UserData;
 }

--- a/nitf/nitf_img_subheader.ddl
+++ b/nitf/nitf_img_subheader.ddl
@@ -60,11 +60,11 @@ def IRep = Choose {
   monochrome = @(PadWSpaces 8 (Match "MONO")) ;
   rgb = @(PadWSpaces 8 (Match "RGB")) ;
   rgblut = @(PadWSpaces 8 (Match "RGB/LUT")) ;
-  multi = @(PadWSpaces 8 (Match "MULTI")) ; 
+  multi = @(PadWSpaces 8 (Match "MULTI")) ;
   nodisplay = @(PadWSpaces 8 (Match "NODISPLY")) ;
   cartesian = @(PadWSpaces 8 (Match "NVECTOR")) ;
   polar = @(PadWSpaces 8 (Match "POLAR")) ;
-  sar = @(PadWSpaces 8 (Match "VPH")) ; 
+  sar = @(PadWSpaces 8 (Match "VPH")) ;
   itur = @(PadWSpaces 8 (Match "YCbCr601")) ;
 }
 
@@ -166,7 +166,7 @@ def UtmZone = {
 def FiveDigitNum = {
   @v = Many 5 Digit ;
   ^ numBase 10 v
-} 
+}
 
 def PlainUtm = {
   utm = Many 2 Numeral ;
@@ -175,8 +175,8 @@ def PlainUtm = {
 }
 
 def OmitIO lb ub = Match1 (
-  lb .. 'H' 
-| 'J' .. 'N' 
+  lb .. 'H'
+| 'J' .. 'N'
 | 'P' .. ub
 )
 
@@ -256,7 +256,7 @@ def IC = Choose {
 }
 
 def ComRat (ic : IC) = Choose {
-  dim_coding = { 
+  dim_coding = {
       ic is c1
     | ic is m1 ;
     Choose {
@@ -264,7 +264,7 @@ def ComRat (ic : IC) = Choose {
       twods = @(PadWSpaces 4 (Match "2DS")) ;
       twodh = @(PadWSpaces 4 (Match "2DH")) ;
     } ;
-  } ; 
+  } ;
   quant_tables = {
       ic is c3
     | ic is c5
@@ -281,7 +281,7 @@ def ComRat (ic : IC) = Choose {
     | {   ic is c3
         | ic is i1
         | ic is m3 }
-  } ; 
+  } ;
   bits_per_pixel = {
       ic is c4
     | ic is m4 ;
@@ -329,7 +329,7 @@ def NBands (irep : IRep) = (
   }
 | IsNum 1 0
 )
-  
+
 def XBands n = BoundedNum 5 10 99999
 
 def IRepBandN = Choose {
@@ -360,7 +360,7 @@ def ISubCatN = Choose {
   default = @(Spaces 6) ;
   userdef = Many 6 BCSA ;
 }
-  
+
 def IFCN = Match1 'N'  -- other values reserved for future use
 
 def ImFltN = Spaces 3 -- reserved for future use
@@ -431,12 +431,12 @@ def IMag = Choose {
     Guard (fplen <= 4) ;
     Spaces (4 - fplen)
   } ;
-  frac = { 
+  frac = {
     Match1 '/' ;
     $$ = Many (..3) Digit ;
     @fplen = ^ (length $$) + 1 ;
     Guard (fplen <= 4) ;
-    Spaces (4 - fplen) 
+    Spaces (4 - fplen)
   }
 }
 
@@ -576,7 +576,7 @@ def CatParams (icat : ICat) (isubcat : ISubCatN) nbands (pvtype : PVType) nbpp a
         Guard (abpp == 1) }
     | {   Guard (nbands == 1)
         | Guard (nbands == 3) ;
-          { pvtype is integer ; CatIntFull nbpp abpp } 
+          { pvtype is integer ; CatIntFull nbpp abpp }
         | { pvtype is real ; CatReals nbpp abpp } } }
 | {   icat is sideLooking
     | icat is thermalInfrared
@@ -599,7 +599,7 @@ def CatParams (icat : ICat) (isubcat : ISubCatN) nbands (pvtype : PVType) nbpp a
     Guard (nbands == 1) ;
       { pvtype is integer ; CatIntFull nbpp abpp }
     | { pvtype is real ; CatReals nbpp abpp } }
-| {   icat is colorPhoto 
+| {   icat is colorPhoto
     | icat is colorPatch ;
       isubcat is default
     | @(isubcat is userdef) ;
@@ -774,7 +774,7 @@ def ISHeader = {
         lutd_nm = LutdNM nlutsn ;
       } ;
       no_luts = Guard (nlutsn == 0)
-    } 
+    }
   } ;
 
   ISync ;

--- a/nitf/nitf_lib.ddl
+++ b/nitf/nitf_lib.ddl
@@ -1,4 +1,4 @@
--- Combinator to run a parser on a fixed-size chunk 
+-- Combinator to run a parser on a fixed-size chunk
 
 def Chunk n P =  {
   @cur  = GetStream;
@@ -23,22 +23,22 @@ def strlen s = for (len = (0 : int); c in s) (len + 1)
 
 -- parsers:
 
--- Force the parser to backtrack 
+-- Force the parser to backtrack
 def MyFail = { commit; Choose {}; }
 
 def Etx = Match1 4
 
-{-- Character sets --} 
+{-- Character sets --}
 
--- BCS character set 
+-- BCS character set
 def BCS = Match1 (0x20 .. 0x7E | 0x0C | 0x0D)
 def BCSA = Match1 (0x20 .. 0x7E )
 def BCSN = Match1 (0x30 .. 0x39 | 0x2B | 0x2D )
 
--- ECS character set 
--- TODO: work out error handling if deprecated ECS codes are used 
-def ECS = BCS 
-def ECSA = BCSA 
+-- ECS character set
+-- TODO: work out error handling if deprecated ECS codes are used
+def ECS = BCS
+def ECSA = BCSA
 
 def LowerCase = Match1 ('a' .. 'z')
 
@@ -113,7 +113,7 @@ def Byte = Match1 (0 .. 255)
 
 def Spaces (n : uint 64) = Many n (Match1 ' ')
 
-def PadWSpaces n P = 
+def PadWSpaces n P =
   Chunk n {$$ = P; Many (Match1 ' '); END}
 
 def DefaultByte D P = Choose {
@@ -206,7 +206,7 @@ def LiftDate (d : Date) : PartialDate = {
   partCentury = ^ {| actual = d.century |} ;
   partYear = ^ {| actual = d.year |} ;
   partMonth = ^ {| actual = d.month |} ;
-  partDay = ^ {| actual = d.day |} 
+  partDay = ^ {| actual = d.day |}
 }
 
 def PartialTime = {
@@ -218,12 +218,12 @@ def PartialTime = {
 def LiftTime (t : Time) : PartialTime = {
   partHour = ^ {| actual = t.hour |} ;
   partMin = ^ {| actual = t.min |} ;
-  partSecond = ^ {| actual = t.second |} 
+  partSecond = ^ {| actual = t.second |}
 }
 
 def PartialDateTime = {
   partDate = PartialDate ;
-  partTime = PartialTime 
+  partTime = PartialTime
 }
 
 def LiftDateTime (dt : DateTime) : PartialDateTime = {
@@ -231,16 +231,16 @@ def LiftDateTime (dt : DateTime) : PartialDateTime = {
   partTime = LiftTime dt.time
 }
 
-def PartialOrdDate (d0 : PartialDate) (d1 : PartialDate) = 
+def PartialOrdDate (d0 : PartialDate) (d1 : PartialDate) =
   PartialLt d0.partCentury d1.partCentury
 | { PartialEq d0.partCentury d1.partCentury ;
       PartialLt d0.partYear d1.partYear
     | { PartialEq d0.partYear d1.partYear ;
-          PartialLt d0.partMonth d1.partMonth 
+          PartialLt d0.partMonth d1.partMonth
         | { PartialEq d0.partMonth d1.partMonth ;
             PartialLeq d0.partDay d1.partDay } } }
 
-def PartialOrdTime (t0 : PartialTime) (t1 : PartialTime) = 
+def PartialOrdTime (t0 : PartialTime) (t1 : PartialTime) =
   PartialLt t0.partHour t1.partHour
 | { PartialEq t0.partHour t1.partHour ;
       PartialLt t0.partMin t1.partMin
@@ -249,7 +249,7 @@ def PartialOrdTime (t0 : PartialTime) (t1 : PartialTime) =
 
 def PartialOrdDateTime (dt0 : PartialDateTime) (dt1 : PartialDateTime) = {
   PartialOrdDate dt0.partDate dt1.partDate ;
-  PartialOrdTime dt0.partTime dt1.partTime 
+  PartialOrdTime dt0.partTime dt1.partTime
 }
 
 -- OrdDate: check that two dates are ordered
@@ -264,8 +264,8 @@ def SecClas = Choose {
   topsecret = @Match1 'T' ;
   secret = @Match1 'S' ;
   confidential = @Match1 'C' ;
-  restricted = @Match1 'R' ; 
-  unclassified = @Match1 'U' ; 
+  restricted = @Match1 'R' ;
+  unclassified = @Match1 'U' ;
 }
 
 def CountryCode = Many 2 AlphaNum
@@ -343,7 +343,7 @@ def Declassification = {
     decldate = {
       -- TODO: cleanup parens
       (dctp is date | dctp is datelv) ;
-      Date 
+      Date
     } ;
     nodate = {
       ( dctp is event
@@ -352,7 +352,7 @@ def Declassification = {
       | dctp is exempt
       | dctp is none) ;
       Spaces 8
-    } 
+    }
   } ;
   dxcm = Choose {
     reason = {
@@ -396,7 +396,7 @@ def Declassification = {
   dgdt = Choose {
     hasdgdt = {
       dctp is datelv ;
-      Date 
+      Date
     } ;
     nodgdt = @{
         dctp is date
@@ -452,7 +452,7 @@ def CommonSubheader = {
   rel = Release ;
   decl = Declassification ;
   clauth = ClassificationAuthority ;
-  sec = Security 
+  sec = Security
 }
 
 def Encryp = Match1 '0'

--- a/nitf/nitf_main.ddl
+++ b/nitf/nitf_main.ddl
@@ -1,5 +1,5 @@
 import nitf_lib
-import nitf_header 
+import nitf_header
 import nitf_img_subheader
 import nitf_graphic_subheader
 import nitf_text_subheader
@@ -21,31 +21,31 @@ def CheckDateTime fdt dt = @{
    PartialOrdDateTime dt fdt ;
 }
 
-def Main = { 
+def Main = {
     h = Header;
     @ldt = LiftDateTime h.fdt ;
 
     -- parse each image segment:
-    img_segments = 
-      map (imglens in h.li) { 
+    img_segments =
+      map (imglens in h.li) {
         imgHeader = ISHeader ;
         CheckDateTime ldt imgHeader.idatim ;
 
         -- parse the bytes in the data segment
         -- imgData = Many imglens.li Byte ;
       };
-    
+
     -- parse each graphic segment:
-    graph_segments = 
-      map (gls in h.graphlens) {  
+    graph_segments =
+      map (gls in h.graphlens) {
         graphHeader = GraphicHeader ;
 
         -- parse the bytes in the data segment
         graphData = Many (gls.seglen as! uint 64) Byte ;
-      } ; 
+      } ;
 
     -- parse each text segment:
-    txt_segments = 
+    txt_segments =
       map (textls in h.textlens) {
         txtHeader = TextHeader ;
 
@@ -56,7 +56,7 @@ def Main = {
       };
 
     -- parse each data-extension segment:
-    dataExt_segments = 
+    dataExt_segments =
       map (dataextls in h.dataextlens) {
         dataExtHeader = DataExtHeader ;
 
@@ -65,8 +65,8 @@ def Main = {
       } ;
 
     -- parse each reserved-extension segment:
-    reservedExt_segments = 
-      map (resextls in h.resextlens) { 
+    reservedExt_segments =
+      map (resextls in h.resextlens) {
         resExtHeader = ResExtHeader ;
 
         -- parse the bytes in the reserved extension data segment
@@ -75,4 +75,4 @@ def Main = {
 
     -- TEST: enable to fail JITC Neg Format cases
     -- END;
-} 
+}

--- a/nitf/nitf_res_ext_subheader.ddl
+++ b/nitf/nitf_res_ext_subheader.ddl
@@ -12,7 +12,7 @@ def ResExtHeader = {
   resshl = UnsignedNum 4 as? uint 64;
   resshf = Many resshl BCSA ;
 
-  Many Byte 
+  Many Byte
 
   -- TODO: refactor above fields into lib
 }

--- a/nitf/regression.sh
+++ b/nitf/regression.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+FILENAME=regression_nitf.txt
+OUTPUT=/tmp/${FILENAME}
+WHICH_NITF=""
+NITF_MODERN="--nitf-modern"
+
+for arg in "$@"
+do
+    case $arg in
+        "--init" )
+            OUTPUT=${FILENAME}
+            ISINIT="True"
+            NITF_MODERN=""
+            ;;
+    esac
+done
+
+
+./test_all.sh --count ${WHICH_NITF} ${NITF_MODERN} | tee ${OUTPUT}
+./test_all.sh --count ${WHICH_NITF} ${NITF_MODERN} --gwg | tee -a ${OUTPUT}
+
+if [ -z ${ISINIT} ] ; then
+    diff $FILENAME /tmp/$FILENAME
+fi

--- a/nitf/regression_nitf.txt
+++ b/nitf/regression_nitf.txt
@@ -1,0 +1,170 @@
+Positive tests (should pass):
+ JITC - NITF Test Data - Set 1/Format/POS/NITF_FMT_POS_05.NTF ... fail
+ JITC - NITF Test Data - Set 1/Format/POS/NITF_FMT_POS_06.NTF ... pass
+--- Found 1 results:
+ JITC - NITF Test Data - Set 1/Format/POS/NITF_FMT_POS_07.NTF ... pass
+--- Found 1 results:
+ JITC - NITF Test Data - Set 1/Format/POS/NITF_FMT_POS_01.NITF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Format/POS/NITF_FMT_POS_02.NTF ... fail
+ JITC - NITF Test Data - Set 1/Format/POS/NITF_FMT_POS_08.NTF ... fail
+ JITC - NITF Test Data - Set 1/Geospatial/POS/NITF_GEO_POS_08.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Geospatial/POS/NITF_GEO_POS_09.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Geospatial/POS/NITF_GEO_POS_01.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Geospatial/POS/NITF_GEO_POS_02.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Geospatial/POS/NITF_GEO_POS_03.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Geospatial/POS/NITF_GEO_POS_07.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Geospatial/POS/NITF_GEO_POS_06.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Geospatial/POS/NITF_GEO_POS_10.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Geospatial/POS/NITF_GEO_POS_04.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Geospatial/POS/NITF_GEO_POS_05.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_04.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_10.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_11.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_05.NTF ... pass
+--- Found 32 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_13.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_07.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_06.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_12.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_16.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_02.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_03.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_17.NTF ... fail
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_01.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_15.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_14.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_19.NTF ... fail
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_18.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_08.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_20.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/POS/NITF_SEC_POS_09.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Temporal/POS/NITF_TEM_POS_01.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Temporal/POS/NITF_TEM_POS_03.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Temporal/POS/NITF_TEM_POS_02.NTF ... fail
+ JITC - NITF Test Data - Set 1/Temporal/POS/NITF_TEM_POS_05.NTF ... pass
+--- Found 3072 results:
+ JITC - NITF Test Data - Set 1/Temporal/POS/NITF_TEM_POS_04.NTF ... pass
+--- Found 48 results:
+
+Negative tests (should fail):
+ JITC - NITF Test Data - Set 1/Format/NEG/NITF_FMT_NEG_01.NTF ... fail
+ JITC - NITF Test Data - Set 1/Format/NEG/NITF_FMT_NEG_03.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Format/NEG/NITF_FMT_NEG_02.NTF ... fail
+ JITC - NITF Test Data - Set 1/Format/NEG/NITF_FMT_NEG_04.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Geospatial/NEG/NITF_GEO_NEG_04.NTF ... fail
+ JITC - NITF Test Data - Set 1/Geospatial/NEG/NITF_GEO_NEG_05.NTF ... fail
+ JITC - NITF Test Data - Set 1/Geospatial/NEG/NITF_GEO_NEG_02.NTF ... fail
+ JITC - NITF Test Data - Set 1/Geospatial/NEG/NITF_GEO_NEG_03.NTF ... fail
+ JITC - NITF Test Data - Set 1/Geospatial/NEG/NITF_GEO_NEG_01.NTF ... fail
+ JITC - NITF Test Data - Set 1/Security/NEG/NITF_SEC_NEG_01.NTF ... fail
+ JITC - NITF Test Data - Set 1/Security/NEG/NITF_SEC_NEG_02.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/NEG/NITF_SEC_NEG_03.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/NEG/NITF_SEC_NEG_07.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Security/NEG/NITF_SEC_NEG_06.NTF ... fail
+ JITC - NITF Test Data - Set 1/Security/NEG/NITF_SEC_NEG_04.NTF ... fail
+ JITC - NITF Test Data - Set 1/Security/NEG/NITF_SEC_NEG_05.NTF ... fail
+ JITC - NITF Test Data - Set 1/Security/NEG/NITF_SEC_NEG_08.NTF ... fail
+ JITC - NITF Test Data - Set 1/Security/NEG/NITF_SEC_NEG_09.NTF ... pass
+--- Found 16 results:
+ JITC - NITF Test Data - Set 1/Temporal/NEG/NITF_TEM_NEG_05.NTF ... fail
+ JITC - NITF Test Data - Set 1/Temporal/NEG/NITF_TEM_NEG_04.NTF ... fail
+ JITC - NITF Test Data - Set 1/Temporal/NEG/NITF_TEM_NEG_03.NTF ... fail
+ JITC - NITF Test Data - Set 1/Temporal/NEG/NITF_TEM_NEG_02.NTF ... fail
+ JITC - NITF Test Data - Set 1/Temporal/NEG/NITF_TEM_NEG_01.NTF ... fail
+./gwg.nga.mil_samples/i_3301k.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3303a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3301h.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3117ax.ntf ... fail
+./gwg.nga.mil_samples/i_3051e.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3114e.ntf ... fail
+./gwg.nga.mil_samples/i_3090m.ntf ... fail
+./gwg.nga.mil_samples/i_3041a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3128b.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3113g.ntf ... fail
+./gwg.nga.mil_samples/i_3309a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3450c.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3201c.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_5012c.ntf ... fail
+./gwg.nga.mil_samples/i_3076a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3060a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3430a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3001a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3034c.ntf ... fail
+./gwg.nga.mil_samples/i_3405a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3311a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3018a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3063f.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3034f.ntf ... fail
+./gwg.nga.mil_samples/i_3015a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3301c.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3008a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3090u.ntf ... fail
+./gwg.nga.mil_samples/i_3228e.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3301a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3068a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3025b.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3052a.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3228c.ntf ... pass
+--- Found 1 results:
+./gwg.nga.mil_samples/i_3004g.ntf ... pass
+--- Found 1 results:

--- a/nitf/test_all.sh
+++ b/nitf/test_all.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+
+TMPFILE="/dev/null"
+NITF_FOLDER=""
+USING_GEN=""
+
+
+GWG_DIR=./gwg.nga.mil_samples
+
+# echo "args are:"
+# echo "$@"
+
+for arg in "$@"
+do
+    case $arg in
+        "--gen" )
+            USING_GEN="--gen";;
+        "--nitf-modern" )
+            NITF_FOLDER="nitf-modern/";;
+        "--count" )
+            TMPFILE=/tmp/nitf_test_output.txt
+            COUNT="True"
+            ;;
+        "--gwg" )
+            GWG="True"
+            ;;
+        *)
+            echo "Unkown argument: ${arg}"
+            exit 1
+            ;;
+     esac
+done
+
+test_jitc(){
+    # This approach taken from http://mywiki.wooledge.org/BashFAQ/001
+    printf "Positive tests (should pass):\n"
+    ls -d JITC\ -\ NITF\ Test\ Data\ -\ Set\ 1/*/POS |
+    while read -r dir; do
+        find "$dir" -type f -iname '*.ntf' -o -iname '*.nitf' |
+        while read -r file; do
+            printf ' %s ... ' "$file"
+            if cabal run ../:daedalus -- ${NITF_FOLDER}nitf_main.ddl -i"$file" ${USING_GEN} > ${TMPFILE}; then
+
+                printf "pass\n"
+                if [ ! -z "$COUNT" ];
+                then
+                    cat ${TMPFILE} | head -n 2 | tail -n 1
+                fi
+            else
+                printf "fail\n"
+            fi
+        done
+    done
+
+    printf "\nNegative tests (should fail):\n"
+    ls -d JITC\ -\ NITF\ Test\ Data\ -\ Set\ 1/*/NEG |
+    while read -r dir; do
+        find "$dir" -type f -iname '*.ntf' -o -iname '*.nitf' |
+        while read -r file; do
+            printf ' %s ... ' "$file"
+            if cabal run ../:daedalus --  ${NITF_FOLDER}nitf_main.ddl -i"$file" ${USING_GEN} > ${TMPFILE}; then
+                printf "pass\n"
+                if [ ! -z "$COUNT" ];
+                then
+                    cat ${TMPFILE} | head -n 2 | tail -n 1
+                fi
+            else
+                printf "fail\n"
+            fi
+        done
+    done
+}
+
+test_gwg(){
+    find "${GWG_DIR}" -type f -iname '*.ntf' -o -iname '*.nitf' |
+    while read -r file; do
+        printf '%s ... ' "$file"
+        if cabal run ../:daedalus -- nitf-modern/nitf_main.ddl -i"$file" > ${TMPFILE}; then
+            printf "pass\n"
+            if [ ! -z "$COUNT" ];
+            then
+                cat ${TMPFILE} | head -n 2 | tail -n 1
+            fi
+        else
+            printf "fail\n"
+        fi
+    done
+}
+
+if [ -z "$GWG" ]; then
+    test_jitc
+else
+    test_gwg
+fi

--- a/src/Daedalus/ParserGen/Action.hs
+++ b/src/Daedalus/ParserGen/Action.hs
@@ -251,7 +251,7 @@ isUnhandledAction act =
     SAct sact ->
       case sact of
         MapInsert {} -> True
-        -- Guard _ -> True
+        Guard _ -> True
         -- CoerceCheck {} -> True
         _ -> False
     _ -> False

--- a/src/Daedalus/ParserGen/LL/DFA.hs
+++ b/src/Daedalus/ParserGen/LL/DFA.hs
@@ -200,8 +200,8 @@ getFinalStates dfa =
   (Set.toList (finalLinDFAState dfa))
 
 
-showDFA :: DFA -> String
-showDFA dfa =
+showDFA :: Aut a => a -> DFA -> String
+showDFA _aut dfa =
   showTrans [] 0 (startLinDFAState dfa)
   where
     showTrans :: [LinDFAState] -> Int -> LinDFAState -> String
@@ -252,7 +252,7 @@ showDFA dfa =
                 let alts = Closure.getAltSeq $ dstEntry entry
                 in
                   "(" ++ show (length alts) ++
-                  -- ",q" ++ showSlkCfg (Closure.lastCfg (dstEntry entry)) ++
+                  -- ",q" ++ showSlkCfgWithAut _aut (Closure.lastCfg (dstEntry entry)) ++
                   ")," ++ b) "" s  ++ "]"
 
     space d = spaceHelper 0

--- a/src/Daedalus/ParserGen/LL/DFAStep.hs
+++ b/src/Daedalus/ParserGen/LL/DFAStep.hs
@@ -5,6 +5,7 @@ module Daedalus.ParserGen.LL.DFAStep
     DFAEntry(..),
     getInfoEntry,
     DFARegistry,
+    showDFARegistry,
     IteratorDFARegistry,
     initIteratorDFARegistry,
     nextIteratorDFARegistry,
@@ -110,6 +111,9 @@ type DFARegistry = Set.Set DFAEntry
 
 type IteratorDFARegistry = Iterator DFARegistry
 
+showDFARegistry :: Aut a => a -> DFARegistry -> String
+showDFARegistry aut reg =
+  concatMap (\ x -> Slk.showSlkCfgWithAut aut (srcEntry x) ++ "\n") reg
 
 initIteratorDFARegistry :: DFARegistry -> IteratorDFARegistry
 initIteratorDFARegistry r =

--- a/src/Daedalus/ParserGen/LL/LLA.hs
+++ b/src/Daedalus/ParserGen/LL/LLA.hs
@@ -581,7 +581,7 @@ printLLA aut lla cond =
             then
               do
                 mapM_ putStrLn ann
-                putStrLn $ showDFA dfa
+                putStrLn $ showDFA aut dfa
                 putStrLn ""
             else
               return ()
@@ -596,7 +596,7 @@ printAmbiguities aut lla =
       tMapped = Map.fromList tAnnotated
       tOrdered = Map.assocs tMapped
   in
-  if length t > 1000
+  if length t > 10000
   then do return ()
   else
     mapM_
@@ -740,6 +740,8 @@ statsLLA aut llas =
                     result ("-" ++ show k)
                 | flagHasNoAbort dfa == Just True =
                     -- trace (show q) $
+                    -- trace (showDFA aut dfa) $
+                    -- trace (show $ flagHasNoAbort dfa) $
                     result ("-ambiguous-" ++ show k)
                 | otherwise = "abort-" ++ show k
           in

--- a/src/Daedalus/ParserGen/LL/SlkCfg.hs
+++ b/src/Daedalus/ParserGen/LL/SlkCfg.hs
@@ -220,13 +220,13 @@ data SlkBetweenItv =
   deriving (Eq, Ord)
 
 instance Show SlkBetweenItv where
-  show (SlkCExactly v) = "Ex " ++ showSlk v
+  show (SlkCExactly v) = "Exactly " ++ showSlk v
   show (SlkCBetween a b) =
     case (a,b) of
-      (Nothing, Nothing) -> "Bet (-,-)"
-      (Just v, Nothing) -> "Bet (" ++ showSlk v ++ ",-)"
-      (Nothing,  Just v) -> "Bet (-," ++ showSlk v ++ ")"
-      (Just v1,  Just v2) -> "Bet (" ++ showSlk v1 ++ "," ++ showSlk v2 ++ ")"
+      (Nothing, Nothing) -> "Between (-,-)"
+      (Just v, Nothing) -> "Between (" ++ showSlk v ++ ",-)"
+      (Nothing,  Just v) -> "Between (-," ++ showSlk v ++ ")"
+      (Just v1,  Just v2) -> "Between (" ++ showSlk v1 ++ "," ++ showSlk v2 ++ ")"
 
 data SlkActivationFrame =
     SlkListArgs [SlkValue]
@@ -249,7 +249,7 @@ showSlkControlData aut ctrl =
       showSlkControlData aut rest ++
       [ T.unpack (PAST.name2Text _name) ++ " callsite " ++ Aut.stateToString q aut ]
     SCons (SlkManyFrame b i) rest ->
-      showSlkControlData aut rest ++ [ "Many"  ++ " (" ++ show b ++ ", " ++ show i ++ ")" ]
+      showSlkControlData aut rest ++ [ "Many"  ++ " (" ++ show b ++ ", " ++ showSlk i ++ ")" ]
     SEmpty ->  []
 
 

--- a/tests/parser-gen/D007.test.stdout
+++ b/tests/parser-gen/D007.test.stdout
@@ -2,7 +2,7 @@ Stack:
     *
     Main callsite __START__
     _A callsite Main (13,13)-(13,13)
-    Many
+    Many (Between (-,-), *)
 Start: _A (4,5)-(4,28)
 SlkCfg{ q:10, ctrl:[?, ?, ?, *], sem:[?, ], inp:--- }
 DTrans [
@@ -41,7 +41,7 @@ Stack:
     *
     Main callsite __START__
     _B callsite Main (14,13)-(14,13)
-    Many
+    Many (Between (-,-), *)
 Start: _B (8,5)-(8,28)
 SlkCfg{ q:26, ctrl:[?, ?, ?, *], sem:[?, ], inp:--- }
 DTrans [

--- a/tests/parser-gen/D008.test.stdout
+++ b/tests/parser-gen/D008.test.stdout
@@ -3,7 +3,7 @@ Stack:
     Main callsite __START__
     _PadWSpaces__26 callsite Main (18,11)-(18,34)
     _Chunk__29 callsite _PadWSpaces__26 (14,3)-(14,40)
-    Many
+    Many (Between (-,-), *)
 Start: _Chunk__29 (14,18)-(14,33)
 SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ?, ], inp:---[2..3] }
 DTrans [
@@ -22,7 +22,7 @@ Stack:
     Main callsite __START__
     _PadWSpaces__26 callsite Main (18,11)-(18,34)
     _Chunk__29 callsite _PadWSpaces__26 (14,3)-(14,40)
-    Many
+    Many (Between (-,-), *)
 Start: _Chunk__29 (14,18)-(14,33)
 SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ?, ], inp:---[3..3] }
 DTrans [
@@ -41,7 +41,7 @@ Stack:
     Main callsite __START__
     _PadWSpaces__27 callsite Main (19,11)-(19,34)
     _Chunk__28 callsite _PadWSpaces__27 (14,3)-(14,40)
-    Many
+    Many (Between (-,-), *)
 Start: _Chunk__28 (14,18)-(14,33)
 SlkCfg{ q:110, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ?, ], inp:---[2..3] }
 DTrans [
@@ -60,7 +60,7 @@ Stack:
     Main callsite __START__
     _PadWSpaces__27 callsite Main (19,11)-(19,34)
     _Chunk__28 callsite _PadWSpaces__27 (14,3)-(14,40)
-    Many
+    Many (Between (-,-), *)
 Start: _Chunk__28 (14,18)-(14,33)
 SlkCfg{ q:110, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ?, ], inp:---[3..3] }
 DTrans [

--- a/tests/parser-gen/D009.test.stdout
+++ b/tests/parser-gen/D009.test.stdout
@@ -3,7 +3,7 @@ Stack:
     Main callsite __START__
     _PadWSpaces__30 callsite Main (18,11)-(18,36)
     _Chunk__35 callsite _PadWSpaces__30 (14,3)-(14,42)
-    Many
+    Many (Between (-,-), *)
 Start: _Chunk__35 (14,20)-(14,35)
 SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ?, ], inp:---[2..3] }
 DTrans [
@@ -22,7 +22,7 @@ Stack:
     Main callsite __START__
     _PadWSpaces__30 callsite Main (18,11)-(18,36)
     _Chunk__35 callsite _PadWSpaces__30 (14,3)-(14,42)
-    Many
+    Many (Between (-,-), *)
 Start: _Chunk__35 (14,20)-(14,35)
 SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ?, ], inp:---[3..3] }
 DTrans [
@@ -41,7 +41,7 @@ Stack:
     Main callsite __START__
     _PadWSpaces__31 callsite Main (19,11)-(19,36)
     _Chunk__34 callsite _PadWSpaces__31 (14,3)-(14,42)
-    Many
+    Many (Between (-,-), *)
 Start: _Chunk__34 (14,20)-(14,35)
 SlkCfg{ q:110, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ?, ], inp:---[2..3] }
 DTrans [
@@ -60,7 +60,7 @@ Stack:
     Main callsite __START__
     _PadWSpaces__31 callsite Main (19,11)-(19,36)
     _Chunk__34 callsite _PadWSpaces__31 (14,3)-(14,42)
-    Many
+    Many (Between (-,-), *)
 Start: _Chunk__34 (14,20)-(14,35)
 SlkCfg{ q:110, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ?, ], inp:---[3..3] }
 DTrans [

--- a/tests/parser-gen/D011.test.stdout
+++ b/tests/parser-gen/D011.test.stdout
@@ -6,7 +6,52 @@ Stack:
     Main callsite __START__
     FL callsite Main (25,10)-(25,11)
     UnsignedNum callsite FL (20,17)-(20,30)
-    Many
+    Many (Exactly 12, 1)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    FL callsite Main (25,10)-(25,11)
+    UnsignedNum callsite FL (20,17)-(20,30)
+    Many (Exactly 12, 10)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    FL callsite Main (25,10)-(25,11)
+    UnsignedNum callsite FL (20,17)-(20,30)
+    Many (Exactly 12, 11)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    FL callsite Main (25,10)-(25,11)
+    UnsignedNum callsite FL (20,17)-(20,30)
+    Many (Exactly 12, 12)
 Start: UnsignedNum (12,9)-(12,23)
 SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
 DTrans [
@@ -19,8 +64,198 @@ DTrans [
 Stack:
     *
     Main callsite __START__
+    FL callsite Main (25,10)-(25,11)
+    UnsignedNum callsite FL (20,17)-(20,30)
+    Many (Exactly 12, 2)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    FL callsite Main (25,10)-(25,11)
+    UnsignedNum callsite FL (20,17)-(20,30)
+    Many (Exactly 12, 3)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    FL callsite Main (25,10)-(25,11)
+    UnsignedNum callsite FL (20,17)-(20,30)
+    Many (Exactly 12, 4)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    FL callsite Main (25,10)-(25,11)
+    UnsignedNum callsite FL (20,17)-(20,30)
+    Many (Exactly 12, 5)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    FL callsite Main (25,10)-(25,11)
+    UnsignedNum callsite FL (20,17)-(20,30)
+    Many (Exactly 12, 6)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    FL callsite Main (25,10)-(25,11)
+    UnsignedNum callsite FL (20,17)-(20,30)
+    Many (Exactly 12, 7)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    FL callsite Main (25,10)-(25,11)
+    UnsignedNum callsite FL (20,17)-(20,30)
+    Many (Exactly 12, 8)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    FL callsite Main (25,10)-(25,11)
+    UnsignedNum callsite FL (20,17)-(20,30)
+    Many (Exactly 12, 9)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
     UnsignedNum callsite Main (26,10)-(26,22)
-    Many
+    Many (Exactly 6, 1)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    UnsignedNum callsite Main (26,10)-(26,22)
+    Many (Exactly 6, 2)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    UnsignedNum callsite Main (26,10)-(26,22)
+    Many (Exactly 6, 3)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    UnsignedNum callsite Main (26,10)-(26,22)
+    Many (Exactly 6, 4)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    UnsignedNum callsite Main (26,10)-(26,22)
+    Many (Exactly 6, 5)
+Start: UnsignedNum (12,9)-(12,23)
+SlkCfg{ q:38, ctrl:[?, ?, ?, *], sem:[?, ?, ], inp:--- }
+DTrans [
+  ( [(31),]
+  , HeadInput ['0','9']
+  , Resolution (NotAmbiguous)
+  ),
+]
+
+Stack:
+    *
+    Main callsite __START__
+    UnsignedNum callsite Main (26,10)-(26,22)
+    Many (Exactly 6, 6)
 Start: UnsignedNum (12,9)-(12,23)
 SlkCfg{ q:38, ctrl:[?, ?, ?, *], sem:[?, ?, ], inp:--- }
 DTrans [
@@ -299,7 +534,7 @@ DTrans [
      *
      Main callsite __START__
      UnsignedNum callsite Main (26,10)-(26,22)
-     Many
+     Many (Exactly 6, 0)
      Digit callsite UnsignedNum (12,19)-(12,23)
      Numeral callsite Digit (9,20)-(9,26)
      MATCH: Numeral (7,15)-(7,32)
@@ -307,7 +542,7 @@ DTrans [
      *
      Main callsite __START__
      UnsignedNum callsite Main (26,10)-(26,22)
-     Many
+     Many (Exactly 6, 0)
      Digit callsite UnsignedNum (12,19)-(12,23)
      Numeral callsite Digit (9,20)-(9,26)
      MATCH: Numeral (7,15)-(7,32)

--- a/tests/parser-gen/D012.todo.test.stdout
+++ b/tests/parser-gen/D012.todo.test.stdout
@@ -3,7 +3,7 @@ Stack:
     Main callsite __START__
     _RGB callsite Main (37,5)-(37,7)
     _Token__29 callsite _RGB (11,11)-(11,23)
-    Many
+    Many (Between (1,-), *)
 Start: _Token__29 (7,3)-(7,15)
 SlkCfg{ q:44, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
 DTrans [
@@ -23,7 +23,7 @@ Stack:
     _RGB callsite Main (37,5)-(37,7)
     _Token__29 callsite _RGB (11,11)-(11,23)
     _Natural callsite _Token__29 (6,8)-(6,8)
-    Many
+    Many (Between (1,-), *)
 Start: _Natural (23,9)-(23,24)
 SlkCfg{ q:22, ctrl:[?, ?, ?, ?, ?, *], sem:[?, ], inp:--- }
 DTrans [
@@ -42,7 +42,7 @@ Stack:
     Main callsite __START__
     _RGB callsite Main (37,5)-(37,7)
     _Token__29 callsite _RGB (12,11)-(12,23)
-    Many
+    Many (Between (1,-), *)
 Start: _Token__29 (7,3)-(7,15)
 SlkCfg{ q:44, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
 DTrans [
@@ -62,7 +62,7 @@ Stack:
     _RGB callsite Main (37,5)-(37,7)
     _Token__29 callsite _RGB (12,11)-(12,23)
     _Natural callsite _Token__29 (6,8)-(6,8)
-    Many
+    Many (Between (1,-), *)
 Start: _Natural (23,9)-(23,24)
 SlkCfg{ q:22, ctrl:[?, ?, ?, ?, ?, *], sem:[?, ], inp:--- }
 DTrans [
@@ -81,7 +81,7 @@ Stack:
     Main callsite __START__
     _RGB callsite Main (37,5)-(37,7)
     _Token__29 callsite _RGB (13,11)-(13,23)
-    Many
+    Many (Between (1,-), *)
 Start: _Token__29 (7,3)-(7,15)
 SlkCfg{ q:44, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
 DTrans [
@@ -101,7 +101,7 @@ Stack:
     _RGB callsite Main (37,5)-(37,7)
     _Token__29 callsite _RGB (13,11)-(13,23)
     _Natural callsite _Token__29 (6,8)-(6,8)
-    Many
+    Many (Between (1,-), *)
 Start: _Natural (23,9)-(23,24)
 SlkCfg{ q:22, ctrl:[?, ?, ?, ?, ?, *], sem:[?, ], inp:--- }
 DTrans [

--- a/tests/parser-gen/D015.test.stdout
+++ b/tests/parser-gen/D015.test.stdout
@@ -6,7 +6,7 @@ Stack:
     Main callsite __START__
     PPM callsite Main (5,8)-(5,10)
     Token__37 callsite PPM (16,14)-(16,26)
-    Many
+    Many (Between (1,-), *)
 Start: Token__37 (11,3)-(11,15)
 SlkCfg{ q:70, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
 AbortClosureUnhandledAction
@@ -18,7 +18,7 @@ Stack:
     PPM callsite Main (5,8)-(5,10)
     Token__37 callsite PPM (16,14)-(16,26)
     Natural callsite Token__37 (10,8)-(10,8)
-    Many
+    Many (Between (1,-), *)
 Start: Natural (28,9)-(28,24)
 SlkCfg{ q:32, ctrl:[?, ?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
 DTrans [
@@ -102,7 +102,7 @@ Stack:
     Main callsite __START__
     PPM callsite Main (5,8)-(5,10)
     Token__37 callsite PPM (16,14)-(16,26)
-    Many
+    Many (Between (1,-), *)
 Start: Token__37 (11,3)-(11,15)
 SlkCfg{ q:70, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
 AbortClosureUnhandledAction

--- a/tests/parser-gen/D021.test.stdout
+++ b/tests/parser-gen/D021.test.stdout
@@ -1,8 +1,8 @@
 Stack:
     *
     Main callsite __START__
-    Many
-    Many
+    Many (Exactly *, *)
+    Many (Exactly *, *)
 Start: Main (11,14)-(11,24)
 SlkCfg{ q:16, ctrl:[?, ?, ?, *], sem:[?, ?, ?, ], inp:--- }
 DTrans [
@@ -15,8 +15,8 @@ DTrans [
 Stack:
     *
     Main callsite __START__
-    Many
-    Many
+    Many (Exactly *, *)
+    Many (Exactly *, *)
 Start: Main (11,14)-(11,24)
 SlkCfg{ q:20, ctrl:[?, ?, ?, *], sem:[?, ?, ?, ], inp:--- }
 DTrans [
@@ -29,8 +29,8 @@ DTrans [
 Stack:
     *
     Main callsite __START__
-    Many
-    Many
+    Many (Exactly *, *)
+    Many (Exactly *, *)
 Start: Main (11,14)-(11,24)
 SlkCfg{ q:22, ctrl:[?, ?, ?, *], sem:[?, ?, ?, ], inp:--- }
 DTrans [

--- a/tests/parser-gen/D022.todo.test.stdout
+++ b/tests/parser-gen/D022.todo.test.stdout
@@ -5,7 +5,7 @@ Stack:
     *
     Main callsite __START__
     _SomeJpeg callsite Main (138,18)-(138,25)
-    Many
+    Many (Between (-,-), *)
     _Segment callsite _SomeJpeg (136,37)-(136,43)
     _COM callsite _Segment (127,15)-(127,17)
     _Payload__122 callsite _COM (44,5)-(44,23)
@@ -19,7 +19,7 @@ Stack:
     *
     Main callsite __START__
     _SomeJpeg callsite Main (138,18)-(138,25)
-    Many
+    Many (Between (-,-), *)
     _Segment callsite _SomeJpeg (136,37)-(136,43)
     _COM callsite _Segment (127,15)-(127,17)
 Start: _COM (44,5)-(44,23)
@@ -35,7 +35,7 @@ Stack:
     *
     Main callsite __START__
     _SomeJpeg callsite Main (138,18)-(138,25)
-    Many
+    Many (Between (-,-), *)
     _Segment callsite _SomeJpeg (136,37)-(136,43)
     _DRI callsite _Segment (128,15)-(128,17)
     _Payload__121 callsite _DRI (81,5)-(81,16)
@@ -49,7 +49,7 @@ Stack:
     *
     Main callsite __START__
     _SomeJpeg callsite Main (138,18)-(138,25)
-    Many
+    Many (Between (-,-), *)
     _Segment callsite _SomeJpeg (136,37)-(136,43)
     _DRI callsite _Segment (128,15)-(128,17)
 Start: _DRI (81,5)-(81,16)
@@ -65,7 +65,7 @@ Stack:
     *
     Main callsite __START__
     _SomeJpeg callsite Main (138,18)-(138,25)
-    Many
+    Many (Between (-,-), *)
 Start: _SomeJpeg (136,32)-(136,43)
 SlkCfg{ q:306, ctrl:[?, ?, ?, *], sem:[?, ?, ], inp:--- }
 DTrans [
@@ -167,7 +167,7 @@ Stack:
     *
     Main callsite __START__
     _SomeJpeg callsite Main (138,18)-(138,25)
-    Many
+    Many (Between (-,-), *)
     _Segment callsite _SomeJpeg (136,37)-(136,43)
     _COM callsite _Segment (127,15)-(127,17)
     _Payload__122 callsite _COM (44,5)-(44,23)
@@ -181,7 +181,7 @@ Stack:
     *
     Main callsite __START__
     _SomeJpeg callsite Main (138,18)-(138,25)
-    Many
+    Many (Between (-,-), *)
     _Segment callsite _SomeJpeg (136,37)-(136,43)
     _DRI callsite _Segment (128,15)-(128,17)
     _Payload__121 callsite _DRI (81,5)-(81,16)

--- a/tests/parser-gen/D023.test.stdout
+++ b/tests/parser-gen/D023.test.stdout
@@ -1,7 +1,7 @@
 Stack:
     *
     Main callsite __START__
-    Many
+    Many (Exactly *, *)
 Start: Main (8,13)-(8,22)
 SlkCfg{ q:32, ctrl:[?, ?, *], sem:[?, ?, ], inp:--- }
 DTrans [

--- a/tests/parser-gen/D025.todo.test.stdout
+++ b/tests/parser-gen/D025.todo.test.stdout
@@ -1,7 +1,7 @@
 Stack:
     *
     Main callsite __START__
-    Many
+    Many (Between (-,-), *)
 Start: Main (12,5)-(12,10)
 SlkCfg{ q:34, ctrl:[?, ?, *], sem:[?, ?, ], inp:--- }
 DTrans [

--- a/tests/parser-gen/plain-ppm2.test.stdout
+++ b/tests/parser-gen/plain-ppm2.test.stdout
@@ -6,7 +6,7 @@ Stack:
     Main callsite __START__
     PPM callsite Main (2,8)-(2,10)
     Token__45 callsite PPM (15,14)-(15,26)
-    Many
+    Many (Between (1,-), *)
 Start: Token__45 (10,3)-(10,15)
 SlkCfg{ q:100, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
 AbortClosureUnhandledAction
@@ -18,7 +18,7 @@ Stack:
     PPM callsite Main (2,8)-(2,10)
     Token__45 callsite PPM (15,14)-(15,26)
     Natural callsite Token__45 (9,8)-(9,8)
-    Many
+    Many (Between (1,-), *)
 Start: Natural (28,9)-(28,24)
 SlkCfg{ q:32, ctrl:[?, ?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
 DTrans [
@@ -103,7 +103,7 @@ Stack:
     Main callsite __START__
     PPM callsite Main (2,8)-(2,10)
     Token__45 callsite PPM (15,14)-(15,26)
-    Many
+    Many (Between (1,-), *)
 Start: Token__45 (10,3)-(10,15)
 SlkCfg{ q:100, ctrl:[?, ?, ?, ?, *], sem:[?, ?, ], inp:--- }
 AbortClosureUnhandledAction


### PR DESCRIPTION
Several `Guard`s in NITF are combined using unbiased choice and sometimes leads to multiple parse solutions. This PR replaces some ambiguous unbiased choices to biased choices. As a result the JITC and milsamples tests return single results on successful parses.