### PR TITLE
Fix some pdf false positive

### DIFF
--- a/pdf-cos/spec/CIDFont.ddl
+++ b/pdf-cos/spec/CIDFont.ddl
@@ -22,7 +22,7 @@ def CIDToGIDMapRec (pos : uint 64) m = Default m
     (inc pos)
     { @hb = UInt8 as uint 16;
       @lb = UInt8 as uint 16;
-      Insert pos ((hb * 256) + lb) m
+      insert pos ((hb * 256) + lb) m
     })
 
 def CIDMap = CIDToGIDMapRec (0 : uint 64) empty

--- a/pdf-cos/spec/CMap.ddl
+++ b/pdf-cos/spec/CMap.ddl
@@ -89,7 +89,7 @@ def DisjointUnion m0 m1 = for (acc1 = m0; rng1, v1 in m1) {
   -- assert that ranges are disjoint
   for (acc0 = {}; rng0, v0 in m0) Guard (disjointRanges rng1 rng0);
   -- add subject binding to map
-  Insert rng1 v1 acc1
+  insert rng1 v1 acc1
 }
 
 -- Overwrite m0 m1: union of range maps m0 and m1, preferring bindings
@@ -428,7 +428,7 @@ def CodeRangeMapToCharCodeMap (crmap : [ CodeRange -> UnicodeSeq ] )  : [ int ->
                        Index css (j as! uint 64);
                      };
                   };
-        Insert key val ccmap2
+        insert key val ccmap2
       }
 
 -- Special Entry Points --------------------------------------------------------

--- a/pdf-cos/spec/CMap.ddl
+++ b/pdf-cos/spec/CMap.ddl
@@ -181,7 +181,7 @@ def CMapVal (k : CMapKey) = case k of
 
 -- UnicodeSeq: a sequence of unicode characters
 def UnicodeSeq cc =
-  Choose {
+  Choose1 {
     -- single unicode char:
     singleUnicode= ParseCharacterCodes;
 

--- a/pdf-cos/spec/Map.ddl
+++ b/pdf-cos/spec/Map.ddl
@@ -24,27 +24,27 @@ def MapDomain m = {
 def mapLength m = length (mapToList m)
 
 -- ListToMap l: collect list of entries l into a map:
-def ListToMap l = for (acc = empty; e in l) (Insert e.key e.value acc)
+def ListToMap l = for (acc = empty; e in l) (insert e.key e.value acc)
 
-def ListOfPairsToMap l = for (acc = empty; e in l) Insert e.fst e.snd acc
+def ListOfPairsToMap l = for (acc = empty; e in l) insert e.fst e.snd acc
 
 -- MapDisjUnion m0 m1: union of disjoint maps m0 and m1
 def MapDisjUnion m0 m1 = for (acc = m0; k1, v1 in m1)
-  Insert k1 v1 acc
+  insert k1 v1 acc
 
-def MapTo d v = for (acc = empty; k in d) Insert k v acc
+def MapTo d v = for (acc = empty; k in d) insert k v acc
 
 def MapUnion m0 m1 = for (acc = m1; k0, v0 in m0)
   (if IsBound k0 m1 then acc
-  else Insert k0 v0 acc)
+  else insert k0 v0 acc)
 
 def UnionMapArray ms = for (acc = empty; m in ms) MapUnion acc m
 
-def ComposeMaps m0 m1 = for (res = empty; k0, v0 in m0) 
-  (Insert k0 (Lookup v0 m1) res)
+def ComposeMaps m0 m1 = for (res = empty; k0, v0 in m0)
+  (insert k0 (Lookup v0 m1) res)
 
 def ComposePartialMaps dflt m0 m1 = for (res = empty; k0, v0 in m0)
-  (Insert k0 (Default dflt (Lookup v0 m1)) res)
+  (insert k0 (Default dflt (Lookup v0 m1)) res)
 
 def TryLookup d k dflt = Default dflt (Lookup d k)
 
@@ -53,5 +53,5 @@ def IsBound k m = Default false (Holds (Lookup k m))
 def Extend k v m = {
   @b = IsBound k m;
   Guard (!b);
-  Insert k v m
+  insert k v m
 }

--- a/pdf-cos/spec/PdfDecl.ddl
+++ b/pdf-cos/spec/PdfDecl.ddl
@@ -225,12 +225,12 @@ def Filter (name : Value) (param : Value) = {
 }
 
 def FilterParam (param : Value) =
-    { param      is null; ^ nothing }
-  | { @x = param is dict; ^ just x }
+     { param      is null; ^ nothing }
+  <| { @x = param is dict; ^ just x }
 
--- Stub for the Decrypt primitive 
-def Decrypt (body : stream) 
-            : stream 
+-- Stub for the Decrypt primitive
+def Decrypt (body : stream)
+            : stream
 
 def TryApplyFilter (f : Filter) (body : stream) =
 

--- a/pdf-cos/spec/PdfValue.ddl
+++ b/pdf-cos/spec/PdfValue.ddl
@@ -87,7 +87,7 @@ def BinaryByte = { x = UInt8;
 --------------------------------------------------------------------------------
 -- Literal Strings (Section 7.3.4.2)
 
-def String = Between "(" ")" StringChars
+def String = { Match1 '('; $$ = StringChars; Match1 ')'; Many JustWhite }
 
 def StringChars = concat (Many StringChunk)
 

--- a/pdf-cos/spec/PdfValue.ddl
+++ b/pdf-cos/spec/PdfValue.ddl
@@ -163,7 +163,7 @@ def Array = Between "[" "]" (Many Value)
 
 def Dict = {
   @ents = Between "<<" ">>" (Many { key = Name; value = Value });
-  for (d = empty; e in ents) (Insert e.key e.value d)
+  for (d = empty; e in ents) (insert e.key e.value d)
 }
 
 

--- a/pdf-cos/spec/PdfXRef.ddl
+++ b/pdf-cos/spec/PdfXRef.ddl
@@ -73,12 +73,12 @@ def CrossRefSubSection = {
 def CrossRefEntry = {
   @num = NatN 10; $space;
   @gen = NatN 5;  $space;
-  $$   = Choose {
+  $$   = Choose1 {
            inUse = UsedEntry num gen;
            free  = FreeEntry num gen;
         };
 
-   { $simpleWS;  $cr | $lf }
+   { $simpleWS;  $cr <| $lf }
     -- standard compliant:
 
     -- | { $cr; $lf }
@@ -86,7 +86,7 @@ def CrossRefEntry = {
     -- Extending the above to allow *commonly allowed* (qpdf, mutool) exuberances:
     -- (which allows the CrossRefEntry to possibly only have 19 bytes):
 
-      | { $cr | $lf ; Choose1{ $cr, $lf, ^0 }};
+    <| { $cr <| $lf ; Choose1{ $cr, $lf, ^0 }}
 }
 
 def UsedEntry (num : int) (gen : int) = {
@@ -158,7 +158,7 @@ def XRefObjTable (meta : XRefMeta) = {
 -- Section 7.5.8.3
 def XRefObjEntry (w : XRefFormat) = Chunk w.width {
   @ftype = XRefFieldWithDefault 1 w.b1;
-  Choose {
+  Choose1 {
     free       = { Guard (ftype == 0); XRefFree w };
     inUse      = { Guard (ftype == 1); XRefOffset w };
     compressed = { Guard (ftype == 2); XRefCompressed w };

--- a/pdf-driver/spec/PdfDemo.ddl
+++ b/pdf-driver/spec/PdfDemo.ddl
@@ -73,7 +73,7 @@ def CheckDecl expectId expectGen (decl : TopDecl) = {
   Guard (decl.gen == expectGen);
   obj    = ^ decl.obj;
   isSafe = { @v = decl.obj is value;  ValueIsSafe v }
-         | {      decl.obj is stream; ^ safeSafetyInfo };
+        <| {      decl.obj is stream; ^ safeSafetyInfo };
 }
 
 def TopDeclCheck expectId expectGen = {

--- a/pdf-simple/PdfValueNew.ddl
+++ b/pdf-simple/PdfValueNew.ddl
@@ -90,7 +90,7 @@ def NumberAsNat (x : Number) = { Guard (x.num >= 0 && x.exp == 0); ^ x.num }
 --------------------------------------------------------------------------------
 -- Literal Strings (Section 7.3.4.2)
 
-def String = { Match1 '('; $$ = StringChars; Match1 ')'; Many JustWhite }
+def String = { Match1 '('; $$ = StringChars 16; Match1 ')'; Many AnyWS }
 
 def StringChars (lim : uint 64) = concat (Many (StringChunk lim))
 

--- a/pdf-simple/PdfValueNew.ddl
+++ b/pdf-simple/PdfValueNew.ddl
@@ -90,7 +90,7 @@ def NumberAsNat (x : Number) = { Guard (x.num >= 0 && x.exp == 0); ^ x.num }
 --------------------------------------------------------------------------------
 -- Literal Strings (Section 7.3.4.2)
 
-def String = Between "(" ")" (StringChars 16)
+def String = { Match1 '('; $$ = StringChars; Match1 ')'; Many JustWhite }
 
 def StringChars (lim : uint 64) = concat (Many (StringChunk lim))
 

--- a/tests/formats/pdf-simple.test.stdout
+++ b/tests/formats/pdf-simple.test.stdout
@@ -146,22 +146,22 @@ PdfValue.Bool : Grammar bool =
  
 PdfValue.Sign : Grammar PdfValue.Sign =
   Choose biased
-    { {- neg -} do (_153 : {}) <- @MatchBytes "-"
-                   pure {neg: _153}
-    | {- pos -} do (_154 : {}) <- @MatchBytes "+"
-                   pure {pos: _154}
-    | {- pos -} do (_155 : {}) <- pure {}
+    { {- neg -} do (_154 : {}) <- @MatchBytes "-"
+                   pure {neg: _154}
+    | {- pos -} do (_155 : {}) <- @MatchBytes "+"
                    pure {pos: _155}
+    | {- pos -} do (_156 : {}) <- pure {}
+                   pure {pos: _156}
     }
  
 PdfValue.Digit : Grammar int =
-  do (_157 : uint 8) <- do (_156 : uint 8) <- Match ('0' .. '9')
-                           pure (_156 - '0')
-     pure (_157 as int)
+  do (_158 : uint 8) <- do (_157 : uint 8) <- Match ('0' .. '9')
+                           pure (_157 - '0')
+     pure (_158 as int)
  
 PdfValue.Natural : Grammar int =
-  do (_158 : [int]) <- Many[ 1 .. ] PdfValue.Digit
-     pure (PdfValue.numBase [int] (uint 64) int 10 _158)
+  do (_159 : [int]) <- Many[ 1 .. ] PdfValue.Digit
+     pure (PdfValue.numBase [int] (uint 64) int 10 _159)
  
 PdfValue.Frac (n : uint 64) (w : PdfValue.Number) : Grammar PdfValue.Number =
   do @MatchBytes "."
@@ -207,22 +207,22 @@ PdfValue.Number : Grammar PdfValue.Number =
                                     pure $$
  
 PdfValue.OctDigit : Grammar int =
-  do (_163 : uint 8) <- do (_162 : uint 8) <- Match ('0' .. '7')
-                           pure (_162 - '0')
-     pure (_163 as int)
+  do (_164 : uint 8) <- do (_163 : uint 8) <- Match ('0' .. '7')
+                           pure (_163 - '0')
+     pure (_164 as int)
  
 PdfValue.HexDigit : Grammar int =
   Choose biased
     { PdfValue.Digit
     | Choose biased
-        { do (_166 : uint 8) <- do (_165 : uint 8) <- do (_164 : uint 8) <- Match ('a' .. 'f')
-                                                         pure (10 + _164)
-                                   pure (_165 - 'a')
-             pure (_166 as int)
-        | do (_169 : uint 8) <- do (_168 : uint 8) <- do (_167 : uint 8) <- Match ('A' .. 'F')
-                                                         pure (10 + _167)
-                                   pure (_168 - 'A')
-             pure (_169 as int)
+        { do (_167 : uint 8) <- do (_166 : uint 8) <- do (_165 : uint 8) <- Match ('a' .. 'f')
+                                                         pure (10 + _165)
+                                   pure (_166 - 'a')
+             pure (_167 as int)
+        | do (_170 : uint 8) <- do (_169 : uint 8) <- do (_168 : uint 8) <- Match ('A' .. 'F')
+                                                         pure (10 + _168)
+                                   pure (_169 - 'A')
+             pure (_170 as int)
         }
     }
  
@@ -237,10 +237,10 @@ PdfValue.NumberAsNat (x : PdfValue.Number) : Grammar int =
      pure $$
  
 PdfValue.StringNumEsc : Grammar [uint 8] =
-  do (_173 : uint 8) <- do (_172 : int) <- do (_171 : [int]) <- Many[ 1 .. 3 ] PdfValue.OctDigit
-                                              pure (PdfValue.numBase [int] (uint 64) int 8 _171)
-                           pure (_172 as uint 8)
-     pure [_173]
+  do (_174 : uint 8) <- do (_173 : int) <- do (_172 : [int]) <- Many[ 1 .. 3 ] PdfValue.OctDigit
+                                              pure (PdfValue.numBase [int] (uint 64) int 8 _172)
+                           pure (_173 as uint 8)
+     pure [_174]
  
 PdfValue.StringEsc : Grammar [uint 8] =
   do @MatchBytes "\\"
@@ -276,17 +276,17 @@ PdfValue.StringEsc : Grammar [uint 8] =
  
 rec value
   PdfValue.StringChars (lim : uint 64) : Grammar [uint 8] =
-    do (_175 : [[uint 8]]) <- Many[] PdfValue.StringChunk lim
-       pure (concat _175)
+    do (_176 : [[uint 8]]) <- Many[] PdfValue.StringChunk lim
+       pure (concat _176)
    
   PdfValue.StringInParens (lim : uint 64) : Grammar [uint 8] =
-    if (lim == 0) then Fail "String nesting limit exceeded" else do (_179 : [[uint 8]]) <- do (_176 : [uint 8]) <- MatchBytes "("
-                                                                                              (_177 : [uint 8]) <- PdfValue.StringChars (lim - 1)
-                                                                                              (_178 : [uint 8]) <- MatchBytes ")"
-                                                                                              pure [_176,
-                                                                                                    _177,
-                                                                                                    _178]
-                                                                    pure (concat _179)
+    if (lim == 0) then Fail "String nesting limit exceeded" else do (_180 : [[uint 8]]) <- do (_177 : [uint 8]) <- MatchBytes "("
+                                                                                              (_178 : [uint 8]) <- PdfValue.StringChars (lim - 1)
+                                                                                              (_179 : [uint 8]) <- MatchBytes ")"
+                                                                                              pure [_177,
+                                                                                                    _178,
+                                                                                                    _179]
+                                                                    pure (concat _180)
    
   PdfValue.StringChunk (lim : uint 64) : Grammar [uint 8] =
     Choose biased
@@ -298,35 +298,39 @@ rec value
       }
  
 PdfValue.String : Grammar [uint 8] =
-  PdfValue.Between [uint 8] "(" ")" (PdfValue.StringChars 16)
+  do @Match {'('}
+     ($$ : [uint 8]) <- PdfValue.StringChars 16
+     @Match {')'}
+     @Many[] PdfValue._AnyWS
+     pure $$
  
 PdfValue.HexStringNum2 : Grammar (uint 8) =
-  do (_181 : int) <- do (_180 : [int]) <- Many[2] PdfValue.Token int PdfValue.HexDigit
-                        pure (PdfValue.numBase [int] (uint 64) int 16 _180)
-     pure (_181 as uint 8)
+  do (_182 : int) <- do (_181 : [int]) <- Many[2] PdfValue.Token int PdfValue.HexDigit
+                        pure (PdfValue.numBase [int] (uint 64) int 16 _181)
+     pure (_182 as uint 8)
  
 PdfValue.HexStringNum1 : Grammar (uint 8) =
-  do (_183 : int) <- do (_182 : int) <- PdfValue.Token int PdfValue.HexDigit
-                        pure (16 * _182)
-     pure (_183 as uint 8)
+  do (_184 : int) <- do (_183 : int) <- PdfValue.Token int PdfValue.HexDigit
+                        pure (16 * _183)
+     pure (_184 as uint 8)
  
 PdfValue.HexString : Grammar [uint 8] =
   PdfValue.Between [uint 8] "<" ">" do (front : [uint 8]) <- Many[] PdfValue.HexStringNum2
                                        ($$ : [uint 8]) <- Choose biased
-                                                            { do (_187 : [[uint 8]]) <- do (_186 : [uint 8]) <- do (_185 : uint 8) <- PdfValue.HexStringNum1
-                                                                                                                   pure [_185]
+                                                            { do (_188 : [[uint 8]]) <- do (_187 : [uint 8]) <- do (_186 : uint 8) <- PdfValue.HexStringNum1
+                                                                                                                   pure [_186]
                                                                                            pure [front,
-                                                                                                 _186]
-                                                                 pure (concat _187)
+                                                                                                 _187]
+                                                                 pure (concat _188)
                                                             | pure front
                                                             }
                                        pure $$
  
 PdfValue.NameEsc : Grammar (uint 8) =
   do @MatchBytes "#"
-     ($$ : uint 8) <- do (_189 : int) <- do (_188 : [int]) <- Many[2] PdfValue.HexDigit
-                                            pure (PdfValue.numBase [int] (uint 64) int 16 _188)
-                         pure (_189 as uint 8)
+     ($$ : uint 8) <- do (_190 : int) <- do (_189 : [int]) <- Many[2] PdfValue.HexDigit
+                                            pure (PdfValue.numBase [int] (uint 64) int 16 _189)
+                         pure (_190 as uint 8)
      PdfValue._Guard (0 < $$)
      pure $$
  
@@ -366,24 +370,24 @@ rec value
    
   PdfValue.Value (lim : uint 64) : Grammar PdfValue.Value =
     if (lim == 0) then Fail "Exceeded value nesting depth" else Choose biased
-                                                                  { {- null -} do (_192 : {}) <- PdfValue.Null
-                                                                                  pure {null: _192}
-                                                                  | {- bool -} do (_193 : bool) <- PdfValue.Bool
-                                                                                  pure {bool: _193}
-                                                                  | {- ref -} do (_194 : PdfValue.Ref) <- PdfValue.Ref
-                                                                                 pure {ref: _194}
-                                                                  | {- name -} do (_195 : [uint 8]) <- PdfValue.Name
-                                                                                  pure {name: _195}
-                                                                  | {- string -} do (_196 : [uint 8]) <- PdfValue.String
-                                                                                    pure {string: _196}
-                                                                  | {- string -} do (_197 : [uint 8]) <- PdfValue.HexString
+                                                                  { {- null -} do (_193 : {}) <- PdfValue.Null
+                                                                                  pure {null: _193}
+                                                                  | {- bool -} do (_194 : bool) <- PdfValue.Bool
+                                                                                  pure {bool: _194}
+                                                                  | {- ref -} do (_195 : PdfValue.Ref) <- PdfValue.Ref
+                                                                                 pure {ref: _195}
+                                                                  | {- name -} do (_196 : [uint 8]) <- PdfValue.Name
+                                                                                  pure {name: _196}
+                                                                  | {- string -} do (_197 : [uint 8]) <- PdfValue.String
                                                                                     pure {string: _197}
-                                                                  | {- number -} do (_198 : PdfValue.Number) <- PdfValue.Number
-                                                                                    pure {number: _198}
-                                                                  | {- array -} do (_199 : [PdfValue.Value]) <- PdfValue.Array (lim - 1)
-                                                                                   pure {array: _199}
-                                                                  | {- dict -} do (_200 : Map [uint 8] PdfValue.Value) <- PdfValue.Dict (lim - 1)
-                                                                                  pure {dict: _200}
+                                                                  | {- string -} do (_198 : [uint 8]) <- PdfValue.HexString
+                                                                                    pure {string: _198}
+                                                                  | {- number -} do (_199 : PdfValue.Number) <- PdfValue.Number
+                                                                                    pure {number: _199}
+                                                                  | {- array -} do (_200 : [PdfValue.Value]) <- PdfValue.Array (lim - 1)
+                                                                                   pure {array: _200}
+                                                                  | {- dict -} do (_201 : Map [uint 8] PdfValue.Value) <- PdfValue.Dict (lim - 1)
+                                                                                  pure {dict: _201}
                                                                   }
  
 PdfValue.PdfDict : Grammar (Map [uint 8] PdfValue.Value) =
@@ -394,7 +398,7 @@ PdfValue.PdfValue : Grammar PdfValue.Value =
  
 PdfValue.NatValue (v : PdfValue.Value) : Grammar int =
   do (n : PdfValue.Number) <- case v is
-                                { {| number = _201 |} -> pure _201
+                                { {| number = _202 |} -> pure _202
                                 }
      ($$ : int) <- PdfValue.NumberAsNat n
      pure $$
@@ -527,7 +531,10 @@ PdfValue._StringChunk (lim : uint 64) : Grammar {} =
     }
  
 PdfValue._String : Grammar {} =
-  PdfValue._Between [uint 8] "(" ")" (PdfValue._StringChars 16)
+  do @Match {'('}
+     PdfValue._StringChars 16
+     @Match {')'}
+     @Many[] PdfValue._AnyWS
  
 PdfValue._HexStringNum2 : Grammar {} =
   @Many[2] PdfValue._Token int PdfValue._HexDigit
@@ -544,9 +551,9 @@ PdfValue._HexString : Grammar {} =
  
 PdfValue._NameEsc : Grammar {} =
   do @MatchBytes "#"
-     ($$ : uint 8) <- do (_189 : int) <- do (_188 : [int]) <- Many[2] PdfValue.HexDigit
-                                            pure (PdfValue.numBase [int] (uint 64) int 16 _188)
-                         pure (_189 as uint 8)
+     ($$ : uint 8) <- do (_190 : int) <- do (_189 : [int]) <- Many[2] PdfValue.HexDigit
+                                            pure (PdfValue.numBase [int] (uint 64) int 16 _189)
+                         pure (_190 as uint 8)
      PdfValue._Guard (0 < $$)
  
 PdfValue._NameChar : Grammar {} =
@@ -601,7 +608,7 @@ PdfValue._PdfValue : Grammar {} =
  
 PdfValue._NatValue (v : PdfValue.Value) : Grammar {} =
   do (n : PdfValue.Number) <- case v is
-                                { {| number = _201 |} -> pure _201
+                                { {| number = _202 |} -> pure _202
                                 }
      PdfValue._NumberAsNat n
 module Pdf
@@ -669,7 +676,7 @@ rec value
  
 Pdf.Stream (val : PdfValue.Value) : Grammar Pdf.Stream =
   do (header : Map [uint 8] PdfValue.Value) <- case val is
-                                                 { {| dict = _205 |} -> pure _205
+                                                 { {| dict = _206 |} -> pure _206
                                                  }
      @MatchBytes "stream"
      PdfValue._SimpleEOL
@@ -681,10 +688,10 @@ Pdf.Stream (val : PdfValue.Value) : Grammar Pdf.Stream =
  
 Pdf.TopDeclDef (val : PdfValue.Value) : Grammar Pdf.TopDeclDef =
   Choose biased
-    { {- stream -} do (_206 : Pdf.Stream) <- Pdf.Stream val
-                      pure {stream: _206}
-    | {- value -} do (_207 : PdfValue.Value) <- pure val
-                     pure {value: _207}
+    { {- stream -} do (_207 : Pdf.Stream) <- Pdf.Stream val
+                      pure {stream: _207}
+    | {- value -} do (_208 : PdfValue.Value) <- pure val
+                     pure {value: _208}
     }
  
 Pdf.ObjDecl : Grammar Pdf.ObjDecl =
@@ -728,10 +735,10 @@ Pdf.CrossRefEntry : Grammar Pdf.CrossRefEntry =
      (gen : uint 64) <- Pdf.NatN 5
      @Match PdfValue.$simpleWS
      ($$ : Pdf.CrossRefEntry) <- Choose biased
-                                   { {- inUse -} do (_210 : Pdf.UsedEntry) <- Pdf.UsedEntry num gen
-                                                    pure {inUse: _210}
-                                   | {- free -} do (_211 : Pdf.FreeEntry) <- Pdf.FreeEntry num gen
-                                                   pure {free: _211}
+                                   { {- inUse -} do (_211 : Pdf.UsedEntry) <- Pdf.UsedEntry num gen
+                                                    pure {inUse: _211}
+                                   | {- free -} do (_212 : Pdf.FreeEntry) <- Pdf.FreeEntry num gen
+                                                   pure {free: _212}
                                    }
      Choose biased
        { do @Match PdfValue.$simpleWS
@@ -746,8 +753,8 @@ Pdf.CrossRefEntry : Grammar Pdf.CrossRefEntry =
  
 Pdf.CrossRefSubSection : Grammar Pdf.CrossRefSubSection =
   do (firstId : int) <- PdfValue.Token int PdfValue.Natural
-     (num : uint 64) <- do (_214 : int) <- PdfValue.Token int PdfValue.Natural
-                           _214 AS uint 64
+     (num : uint 64) <- do (_215 : int) <- PdfValue.Token int PdfValue.Natural
+                           _215 AS uint 64
      (entries : [Pdf.CrossRefEntry]) <- Many[num] Pdf.CrossRefEntry
      pure {firstId = firstId,
            entries = entries}
@@ -776,14 +783,14 @@ Pdf.PdfChunk : Grammar Pdf.PdfChunk =
  
 rec value
   Pdf.SkipTo ?a0 (P : Grammar ?a0) : Grammar {} =
-    do (_216 : bool) <- Choose biased
+    do (_217 : bool) <- Choose biased
                           { do do P
                                   pure {}
                                ($$ : bool) <- pure true
                                pure $$
                           | pure false
                           }
-       case _216 is
+       case _217 is
          { true -> {- case branch  true -} pure {}
          ; false -> {- case branch  false -} do @GetByte
                                                 ($$ : {}) <- Pdf.SkipTo ?a0 P
@@ -809,7 +816,7 @@ Pdf._CountTo ?a0 ?a1 (Literal 1 ?a0) (Arith ?a0) (P : Grammar ?a1) (count : ?a0)
  
 Pdf._Stream (val : PdfValue.Value) : Grammar {} =
   do case val is
-       { {| dict = _205 |} -> pure {}
+       { {| dict = _206 |} -> pure {}
        }
      @MatchBytes "stream"
      PdfValue._SimpleEOL
@@ -867,8 +874,8 @@ Pdf._CrossRefEntry : Grammar {} =
  
 Pdf._CrossRefSubSection : Grammar {} =
   do PdfValue._Token int PdfValue._Natural
-     (num : uint 64) <- do (_214 : int) <- PdfValue.Token int PdfValue.Natural
-                           _214 AS uint 64
+     (num : uint 64) <- do (_215 : int) <- PdfValue.Token int PdfValue.Natural
+                           _215 AS uint 64
      @Many[num] Pdf._CrossRefEntry
  
 Pdf._CrossRefSection : Grammar {} =
@@ -886,13 +893,13 @@ Pdf._PdfChunk : Grammar {} =
      PdfValue._KW "%%EOF"
  
 Pdf._SkipTo ?a0 (P : Grammar ?a0) (_P : Grammar {}) : Grammar {} =
-  do (_216 : bool) <- Choose biased
+  do (_217 : bool) <- Choose biased
                         { do _P
                              ($$ : bool) <- pure true
                              pure $$
                         | pure false
                         }
-     case _216 is
+     case _217 is
        { true -> {- case branch  true -} pure {}
        ; false -> {- case branch  false -} do @GetByte
                                               Pdf.SkipTo ?a0 P


### PR DESCRIPTION
The changes are:
* bugfix on pdf String dll spec in pdf-cos and pdf-simple
* Replace a few unbiased choice with biased choice in pdf-cos
* Use in dictionaries `insert` instead of `Insert` so that it does not fail with duplicate keys