### PR TITLE
Fix to make test-all-backends work

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ Installing Haskell
 
 Daedalus is implemented in Haskell, so to build it you'd need to setup
 a Haskell environment.  An easy way to get this setup is to use ghcup_.
-You need a Haskell compiler (recommended `GHC 8.8.3`), and a Haskell package
-installer (recommended `Cabal 3.2`).
+You need a Haskell compiler (recommended `GHC 8.10.7`), and a Haskell package
+installer (recommended `Cabal 3.6`).
 
 .. _ghcup: https://www.haskell.org/ghcup/
 

--- a/icc-tools/icc-tools.cabal
+++ b/icc-tools/icc-tools.cabal
@@ -38,8 +38,9 @@ library
     Daedalus
 
   autogen-modules:
-    ICC
     Daedalus
+    Debug
+    ICC
     Parser
     Validator
 

--- a/test-all-ways/test.hs
+++ b/test-all-ways/test.hs
@@ -125,7 +125,7 @@ compileHaskell ddl =
         ]
      callProcessIn_ build "cabal" ["build"]
      callProcessIn_ build "rm" ["-f", "parser"]
-     path <- callProcessIn build "cabal" [ "exec", "which", short ddl ]
+     path <- callProcessIn build "cabal" [ "-v0", "exec", "which", short ddl ]
      callProcessIn_ build "ln" ["-s", head (lines path), "parser"]
      pure ()
 


### PR DESCRIPTION
Debug module needs to be autogen listed
invoking cabal exec with -v0 makes it less likely to emit extra outputs.