### PR TITLE
Param entries

### DIFF
--- a/daedalus-core/src/Daedalus/Core/Decl.hs
+++ b/daedalus-core/src/Daedalus/Core/Decl.hs
@@ -30,6 +30,7 @@ data Fun e = Fun
   { fName    :: FName
   , fParams  :: [Name]
   , fDef     :: FunDef e
+  , fIsEntry :: !Bool
   }
   deriving (Functor, Foldable, Traversable, Generic, NFData)
 

--- a/daedalus-core/src/Daedalus/Core/TraverseUserTypes.hs
+++ b/daedalus-core/src/Daedalus/Core/TraverseUserTypes.hs
@@ -73,6 +73,7 @@ instance TraverseUserTypes a => TraverseUserTypes (Fun a) where
     Fun <$> traverseUserTypes f (fName fn)
         <*> traverseUserTypes f (fParams fn)
         <*> traverseUserTypes f (fDef fn)
+        <*> pure (fIsEntry fn)
 
 instance TraverseUserTypes Name where
   traverseUserTypes f n =

--- a/daedalus-vm/src/Daedalus/VM/Backend/C.hs
+++ b/daedalus-vm/src/Daedalus/VM/Backend/C.hs
@@ -367,9 +367,11 @@ cNonCaptureRoot fun = (cStmt sig, sig <+> "{" $$ nest 2 (vcat body) $$ "}")
   body = [ cDeclareVar "DDL::ParserState" "p"
          , cDeclareVar ty "out_result"
          , cDeclareVar "DDL::Input" "out_input"
-         , cIf' call
-              [ cStmt (cCallMethod "results" "push_back" [ "out_result" ]) ]
-         , cStmt (cCallMethod "out_input" "free" [])
+         , cIf call
+              [ cStmt (cCallMethod "results" "push_back" [ "out_result" ])
+              , cStmt (cCallMethod "out_input" "free" [])
+              ]
+              [ cAssign "error.offset" (cCallMethod "p" "getFailOffset" [])]
          ]
 
 

--- a/daedalus-vm/src/Daedalus/VM/Backend/C/Lang.hs
+++ b/daedalus-vm/src/Daedalus/VM/Backend/C/Lang.hs
@@ -121,6 +121,13 @@ cReturn e = cStmt ("return" <+> e)
 cBlock :: [CStmt] -> CStmt
 cBlock xs = vcat [ "{" <+> vcat xs, "}" ]
 
+cArgBlock :: [Doc] -> Doc
+cArgBlock as =
+  case as of
+    [] -> "()"
+    _  -> vcat (zipWith (<+>) start as) $$ ")"
+      where start = "(" : repeat ","
+
 cDefineCon :: CIdent -> [CExpr] -> [(CIdent,CExpr)] -> [CStmt] -> CStmt
 cDefineCon name params is stmts =
   hang (cCall name params) 2 initializers <+> body
@@ -147,6 +154,9 @@ cDeclareFun ty name params = cStmt decl
 cNamespace :: CIdent -> [CDecl] -> CDecl
 cNamespace nm d =
   "namespace" <+> nm <+> "{" $$ nest 2 (vcat d) $$ "}"
+
+cUsingT :: CIdent -> CType -> CDecl
+cUsingT x t = cStmt ("using" <+> x <+> "=" <+> t)
 
 cUnreachable :: CStmt
 cUnreachable = "__builtin_unreachable();"

--- a/daedalus-vm/src/Daedalus/VM/Backend/C/Names.hs
+++ b/daedalus-vm/src/Daedalus/VM/Backend/C/Names.hs
@@ -154,7 +154,10 @@ selName own l = pref <.> "_" <.> cLabel l
 
 
 cFName :: FName -> CIdent
-cFName f = escDoc ("parse_" <.> pp f)
+cFName f = escDoc ("parser_" <.> pp f)
+
+cFEntryName :: FName -> CIdent
+cFEntryName f = escDoc ("parse" <.> pp f)
 
 --------------------------------------------------------------------------------
 isReserved :: Text -> Bool

--- a/daedalus-vm/src/Daedalus/VM/BorrowAnalysis.hs
+++ b/daedalus-vm/src/Daedalus/VM/BorrowAnalysis.hs
@@ -13,8 +13,6 @@ import Daedalus.Core(Op1(..),Op2(..),Op3(..),OpN(..))
 import Daedalus.VM
 import Daedalus.VM.TypeRep
 
-import Debug.Trace
-
 {-
 * Notes on reference variables:
 
@@ -69,7 +67,7 @@ of basic blocks (point 5)
 
 
 doBorrowAnalysis :: Program -> Program
-doBorrowAnalysis prog = traceShow info $ Program { pModules = annModule <$> pModules prog }
+doBorrowAnalysis prog = Program { pModules = annModule <$> pModules prog }
   where
   info        = borrowAnalysis prog
 

--- a/daedalus-vm/src/Daedalus/VM/CaptureAnalysis.hs
+++ b/daedalus-vm/src/Daedalus/VM/CaptureAnalysis.hs
@@ -15,12 +15,7 @@ import Daedalus.VM
 
 
 captureAnalysis :: Program -> Program
-captureAnalysis prog =
-  Program { pModules = map annotateModule ms
-          , pEntries = map annotateEntry (pEntries prog)
-          }
-
-
+captureAnalysis prog = Program { pModules = map annotateModule ms }
   where
   ms = pModules prog
 
@@ -47,15 +42,6 @@ captureAnalysis prog =
   ---
 
   annotateModule m = m { mFuns = map annotateFun (mFuns m) }
-  annotateEntry e =
-    let bs   = entryBoot e
-        c    = case foldMap captureInfo bs of
-                 CapturesYes -> Capture
-                 CapturesIf xs
-                   | any (\x -> getCaptures info x == Capture) xs -> Capture
-                   | otherwise -> NoCapture
-
-    in e { entryBoot = annotateBlock c <$> entryBoot e }
 
   annotateFun f = f { vmfCaptures = me
                     , vmfDef = annotateDef me (vmfDef f)

--- a/daedalus-vm/src/Daedalus/VM/Compile/Decl.hs
+++ b/daedalus-vm/src/Daedalus/VM/Compile/Decl.hs
@@ -6,7 +6,6 @@ import qualified Data.Map as Map
 import qualified Data.Text as Text
 import Data.Void(Void)
 
-import Daedalus.Panic(panic)
 import Daedalus.PP(pp)
 
 import qualified Daedalus.Core as Src
@@ -24,54 +23,25 @@ import Daedalus.VM.TailCallJump
 
 
 
-moduleToProgram :: [Src.FName] -> [Module] -> Program
-moduleToProgram entries ms =
+moduleToProgram :: [Module] -> Program
+moduleToProgram ms =
   tailProgram $
   captureAnalysis
-  Program
-    { pModules = map loopAnalysis ms
-    , pEntries = [ compileEntry entry (Src.Call entry []) | entry <- entries ]
-    }
-
-compileEntry :: Src.FName -> Src.Grammar -> Entry
-compileEntry entry pe =
-  Entry { entryLabel = l
-        , entryBoot  = Map.adjust addArgs l b
-        , entryType  = Src.fnameType entry
-        , entryName  = entName
-        }
-  where
-  entName = Text.pack ("parse" ++ show (pp entry))
-
-  addArgs bl = bl { blockArgs = [inpArg] }
-  (l,b) =
-    runC entName (Src.typeOf pe) $
-    do code <- compile pe
-                  Next { onNo  = Just
-                                 do stmt_ $ Say "Branch failed, resuming"
-                                    term  $ Yield
-                       , onYes = Just \v ->
-                                 do stmt_ $ Say "Branch succeeded, resuming"
-                                    stmt_ $ Output v
-                                    term  $ Yield
-                       }
-       pure (setInput (EBlockArg inpArg) >> code)
-
+  Program { pModules = map loopAnalysis ms }
 
 compileModule :: Src.Module -> Module
 compileModule m =
   Module { mName = Src.mName m
          , mImports = Src.mImports m
          , mTypes = Src.mTypes m
-         , mFuns = map compileFFun (Src.mFFuns m) ++
-                   map compileGFun (Src.mGFuns m)
+         , mFuns  = map compileGFun (Src.mGFuns m)
          }
 
 inpArg :: BA
 inpArg = BA 0 (TSem Src.TStream) Borrowed
 
 compileSomeFun ::
-  Bool -> (Maybe a -> C (BlockBuilder Void)) -> Src.Fun a -> VMFun
+  Bool -> (a -> C (BlockBuilder Void)) -> Src.Fun a -> VMFun
 compileSomeFun isPure doBody fun =
   let xs         = Src.fParams fun
       name       = Src.fName fun
@@ -93,7 +63,7 @@ compileSomeFun isPure doBody fun =
       def = case Src.fDef fun of
                Src.Def e    ->
                  VMDef
-                   let body   = foldr setInp (doBody (Just e)) inpArgs
+                   let body   = foldr setInp (doBody e) inpArgs
                        (l,ls) = runC lab (Src.typeOf name)
                                          (foldr getArgC body (zip xs args))
                    in VMFBody { vmfEntry = l
@@ -113,17 +83,11 @@ compileSomeFun isPure doBody fun =
             , vmfPure   = isPure
             , vmfLoop   = False
             , vmfDef    = def
+            , vmfIsEntry = Src.fIsEntry fun
             }
 
 compileFFun :: Src.Fun Src.Expr -> VMFun
-compileFFun = compileSomeFun True \mb ->
-  case mb of
-    Just e -> compileE e Nothing
-    Nothing -> panic "compileFFun" ["XXX: External primitives"]
+compileFFun = compileSomeFun True \e -> compileE e Nothing
 
 compileGFun :: Src.Fun Src.Grammar -> VMFun
-compileGFun = compileSomeFun False \mb ->
-  case mb of
-    Just e -> compile e ret
-    Nothing -> panic "compileGFun" ["XXX: External primitives"]
-
+compileGFun = compileSomeFun False (\e -> compile e ret)

--- a/daedalus-vm/src/Daedalus/VM/Compile/Decl.hs
+++ b/daedalus-vm/src/Daedalus/VM/Compile/Decl.hs
@@ -34,7 +34,8 @@ compileModule m =
   Module { mName = Src.mName m
          , mImports = Src.mImports m
          , mTypes = Src.mTypes m
-         , mFuns  = map compileGFun (Src.mGFuns m)
+         , mFuns  = map compileFFun (Src.mFFuns m)
+                 ++ map compileGFun (Src.mGFuns m)
          }
 
 inpArg :: BA

--- a/daedalus-vm/src/Daedalus/VM/InsertCopy.hs
+++ b/daedalus-vm/src/Daedalus/VM/InsertCopy.hs
@@ -19,11 +19,8 @@ import Daedalus.VM.FreeVars
 
 
 addCopyIs :: Program -> Program
-addCopyIs p = p { pEntries = annEntry  <$> pEntries p
-                , pModules = annModule <$> pModules p
-                }
+addCopyIs p = Program { pModules = annModule <$> pModules p }
   where
-  annEntry e  = e { entryBoot = blockMap (entryBoot e) }
   annModule m = m { mFuns = map annFun (mFuns m) }
   annFun f    = f { vmfDef = annDef (vmfDef f) }
   annDef d    = case d of
@@ -38,10 +35,7 @@ addCopyIs p = p { pEntries = annEntry  <$> pEntries p
 buildRO :: Program -> RO
 buildRO p = foldr addFun initRO [ f | m <- pModules p, f <- mFuns m ]
   where
-  initRO = RO { funMap = Map.empty
-              , labOwn = Map.unions [ blockSig <$> entryBoot entry
-                                                        | entry <- pEntries p ]
-              }
+  initRO = RO { funMap = Map.empty, labOwn = Map.empty }
 
   addFun f i =
     case vmfDef f of

--- a/daedalus-vm/src/Daedalus/VM/RefCountSane.hs
+++ b/daedalus-vm/src/Daedalus/VM/RefCountSane.hs
@@ -29,11 +29,9 @@ checkProgram prog =
     Right _  -> Nothing
     Left err -> Just err
   where
-  check = do mapM_ checkModule (pModules prog)
-             mapM_ checkEntry  (pEntries prog)
+  check = mapM_ checkModule (pModules prog)
 
   checkModule = mapM_ checkVMFun . mFuns
-  checkEntry  = checkBlocks . entryBoot
   checkVMFun f = case vmfDef f of
                    VMDef b -> checkBlocks (vmfBlocks b)
                    VMExtern {} -> pure ()

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -242,11 +242,11 @@ doToCore opts mm =
 
 doToVM :: Options -> ModuleName -> Daedalus VM.Program
 doToVM opts mm =
-  do ents <- doToCore opts mm
+  do _ <- doToCore opts mm
      passVM specMod
      m <- ddlGetAST specMod astVM
      let addMM = VM.addCopyIs . VM.doBorrowAnalysis
-     pure $ addMM $ VM.moduleToProgram ents [m]
+     pure $ addMM $ VM.moduleToProgram [m]
 
 
 parseEntries :: Options -> ModuleName -> [(ModuleName,Ident)]

--- a/exe/c-template/main.cpp
+++ b/exe/c-template/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
   DDL::ParseError err;
   std::vector<DDL::ResultOf::parseMain> out;
   auto start = std::chrono::high_resolution_clock::now();
-  parseMain(i,err,out);
+  parseMain(err,out,i);
   auto end  = std::chrono::high_resolution_clock::now();
   auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
             .count();

--- a/rts-c/ddl/parser.h
+++ b/rts-c/ddl/parser.h
@@ -27,7 +27,7 @@ class ParserState {
 public:
   ParserState() : fail_offset(0) {}
 
-  Size getFailOffest() { return fail_offset; }
+  Size getFailOffset() { return fail_offset; }
 
   // All alternatives failed.   Free the stack and return the
   // offset of the best error we computed.

--- a/rts-c/ddl/parser.h
+++ b/rts-c/ddl/parser.h
@@ -27,6 +27,8 @@ class ParserState {
 public:
   ParserState() : fail_offset(0) {}
 
+  Size getFailOffest() { return fail_offset; }
+
   // All alternatives failed.   Free the stack and return the
   // offset of the best error we computed.
   Size finalYield() {

--- a/src/Daedalus/Driver.hs
+++ b/src/Daedalus/Driver.hs
@@ -722,6 +722,7 @@ passSpecialize tgt roots =
              mo = TCModule
                     { tcModuleName = tgt
                     , tcModuleImports = []
+                    , tcEntries = rootNames
                     , tcModuleTypes = tdecls
                     , tcModuleDecls = ds
                     }

--- a/src/Daedalus/ParserGen/Compile.hs
+++ b/src/Daedalus/ParserGen/Compile.hs
@@ -376,6 +376,7 @@ allocTCModule n _tc@(TCModule{..}) =
       annotTCModule =
         TCModule
         { tcModuleName = tcModuleName
+        , tcEntries = []
         , tcModuleImports = tcModuleImports
         , tcModuleTypes = tcModuleTypes
         , tcModuleDecls = reverse atc
@@ -421,6 +422,7 @@ allocStates decls =
             NonRec d ->
               let uniModule =
                     TCModule { tcModuleName = tcModuleName
+                             , tcEntries = []
                              , tcModuleImports = tcModuleImports
                              , tcModuleTypes = tcModuleTypes
                              , tcModuleDecls = [ NonRec d ]
@@ -433,6 +435,7 @@ allocStates decls =
         f localM decl =
           let uniModule =
                 TCModule { tcModuleName = tcModuleName
+                         , tcEntries = []
                          , tcModuleImports = tcModuleImports
                          , tcModuleTypes = tcModuleTypes
                          , tcModuleDecls = [ NonRec decl ]

--- a/src/Daedalus/Type.hs
+++ b/src/Daedalus/Type.hs
@@ -52,6 +52,7 @@ inferRules m =
       [] -> pure TCModule
                    { tcModuleName = moduleName m
                    , tcModuleImports = moduleImports m
+                   , tcEntries = []
                    , tcModuleTypes = map sccToRec
                                    $ stronglyConnComp
                                    $ map getDeps

--- a/src/Daedalus/Type/AST.hs
+++ b/src/Daedalus/Type/AST.hs
@@ -344,6 +344,7 @@ data TCDeclDef a k = ExternDecl Type | Defined (TC a k)
 -- | A module consists of a collection of types and a collection of decls.
 data TCModule a = TCModule { tcModuleName    :: ModuleName
                            , tcModuleImports :: [ Located ModuleName ]
+                           , tcEntries       :: ![ Name ]
                            , tcModuleTypes   :: [ Rec TCTyDecl ]
                            , tcModuleDecls   :: [ Rec (TCDecl a) ]
                            } deriving Show


### PR DESCRIPTION
Extend C++ back-end with support for entry points that have arguments.

NOTE:  This changes the API of entry points slightly: previously the input was the 1st argument to an entry point,
now it is the last one (i.e., it comes after the error and results parameters).    The arguments to an entry point all come after the error and output field, and the input is the first of those.