### PR TITLE
Stream to array

### DIFF
--- a/daedalus-core/src/Daedalus/Core/Decl.hs
+++ b/daedalus-core/src/Daedalus/Core/Decl.hs
@@ -30,6 +30,7 @@ data Fun e = Fun
   { fName    :: FName
   , fParams  :: [Name]
   , fDef     :: FunDef e
+  , fIsEntry :: !Bool
   }
   deriving (Functor, Foldable, Traversable, Generic, NFData)
 

--- a/daedalus-core/src/Daedalus/Core/Expr.hs
+++ b/daedalus-core/src/Daedalus/Core/Expr.hs
@@ -46,6 +46,7 @@ data Op1 =
   | Head
   | StreamOffset
   | StreamLen
+  | BytesOfStream
   | OneOf ByteString
   | Neg
   | BitNot
@@ -199,6 +200,7 @@ eTake         = Ap2 Take
 streamOffset  = Ap1 StreamOffset
 streamLen     = Ap1 StreamLen
 arrayStream   = Ap2 ArrayStream
+bytesOfStream = Ap1 BytesOfStream
 
 --------------------------------------------------------------------------------
 -- Relations
@@ -358,6 +360,7 @@ instance PP Op1 where
       Head            -> "iHead"
       StreamOffset    -> "iOffset"
       StreamLen       -> "iLen"
+      BytesOfStream   -> "bytesOfStream"
       OneOf xs        -> "oneOf" <+> pp xs
       Neg             -> "neg"
       BitNot          -> "complement"

--- a/daedalus-core/src/Daedalus/Core/Semantics/Expr.hs
+++ b/daedalus-core/src/Daedalus/Core/Semantics/Expr.hs
@@ -240,6 +240,7 @@ evalOp1 env op ty v = case op of
   Head          -> partial (vStreamHead v)
   StreamOffset  -> vStreamOffset v
   StreamLen     -> vStreamLength v
+  BytesOfStream -> vBytesOfStream v
   OneOf bs      -> VBool $ isJust $ BS.elemIndex (valueToByte v) bs
   Neg           -> partial (vNeg v)
   BitNot        -> vComplement v

--- a/daedalus-core/src/Daedalus/Core/TraverseUserTypes.hs
+++ b/daedalus-core/src/Daedalus/Core/TraverseUserTypes.hs
@@ -73,6 +73,7 @@ instance TraverseUserTypes a => TraverseUserTypes (Fun a) where
     Fun <$> traverseUserTypes f (fName fn)
         <*> traverseUserTypes f (fParams fn)
         <*> traverseUserTypes f (fDef fn)
+        <*> pure (fIsEntry fn)
 
 instance TraverseUserTypes Name where
   traverseUserTypes f n =

--- a/daedalus-core/src/Daedalus/Core/Type.hs
+++ b/daedalus-core/src/Daedalus/Core/Type.hs
@@ -87,6 +87,7 @@ instance TypeOf Expr where
           Head            -> TUInt (TSize 8)
           StreamOffset    -> sizeType
           StreamLen       -> sizeType
+          BytesOfStream   -> TArray (TUInt (TSize 8))
           OneOf _         -> TBool
           Neg             -> typeOf e
           BitNot          -> typeOf e

--- a/daedalus-core/src/Daedalus/Core/TypeCheck.hs
+++ b/daedalus-core/src/Daedalus/Core/TypeCheck.hs
@@ -343,6 +343,7 @@ checkOp1 op arg =
     Head            -> typeIs TStream arg       $> tByte
     StreamOffset    -> typeIs TStream arg       $> sizeType
     StreamLen       -> typeIs TStream arg       $> sizeType
+    BytesOfStream   -> typeIs TStream arg       $> TArray tByte
     OneOf _         -> typeIs tByte   arg       $> sizeType
     Neg             -> isArith arg              $> arg
 

--- a/daedalus-value/src/Daedalus/Value.hs
+++ b/daedalus-value/src/Daedalus/Value.hs
@@ -106,6 +106,7 @@ module Daedalus.Value
   , vStreamLength
   , vStreamTake
   , vStreamDrop
+  , vBytesOfStream
 
   -- * Iterators
   , vIteratorFromArray

--- a/daedalus-value/src/Daedalus/Value/Stream.hs
+++ b/daedalus-value/src/Daedalus/Value/Stream.hs
@@ -9,6 +9,9 @@ vStreamFromArray a b = VStream (newInput nm bs)
   where nm = valueToByteString a
         bs = valueToByteString b
 
+vBytesOfStream :: Value -> Value
+vBytesOfStream = vByteString . inputBytes . valueToStream
+
 vStreamOffset :: Value -> Value
 vStreamOffset = vSize . toInteger . inputOffset . valueToStream
 

--- a/daedalus-vm/src/Daedalus/VM/Backend/C.hs
+++ b/daedalus-vm/src/Daedalus/VM/Backend/C.hs
@@ -367,9 +367,11 @@ cNonCaptureRoot fun = (cStmt sig, sig <+> "{" $$ nest 2 (vcat body) $$ "}")
   body = [ cDeclareVar "DDL::ParserState" "p"
          , cDeclareVar ty "out_result"
          , cDeclareVar "DDL::Input" "out_input"
-         , cIf' call
-              [ cStmt (cCallMethod "results" "push_back" [ "out_result" ]) ]
-         , cStmt (cCallMethod "out_input" "free" [])
+         , cIf call
+              [ cStmt (cCallMethod "results" "push_back" [ "out_result" ])
+              , cStmt (cCallMethod "out_input" "free" [])
+              ]
+              [ cAssign "error.offset" (cCallMethod "p" "getFailOffset" [])]
          ]
 
 

--- a/daedalus-vm/src/Daedalus/VM/Backend/C.hs
+++ b/daedalus-vm/src/Daedalus/VM/Backend/C.hs
@@ -707,6 +707,9 @@ cOp1 x op1 ~[e'] =
     Src.StreamLen ->
       cVarDecl x $ sizeTo64 (cCallMethod e "length" [])
 
+    Src.BytesOfStream ->
+      cVarDecl x $ cCallMethod e "getByteArray" []
+
     Src.OneOf bs ->
       let v     = cVarUse x
           true  = cAssign v (cCall "DDL::Bool" [ "true" ]) $$ cBreak

--- a/daedalus-vm/src/Daedalus/VM/Backend/C/Lang.hs
+++ b/daedalus-vm/src/Daedalus/VM/Backend/C/Lang.hs
@@ -121,6 +121,13 @@ cReturn e = cStmt ("return" <+> e)
 cBlock :: [CStmt] -> CStmt
 cBlock xs = vcat [ "{" <+> vcat xs, "}" ]
 
+cArgBlock :: [Doc] -> Doc
+cArgBlock as =
+  case as of
+    [] -> "()"
+    _  -> vcat (zipWith (<+>) start as) $$ ")"
+      where start = "(" : repeat ","
+
 cDefineCon :: CIdent -> [CExpr] -> [(CIdent,CExpr)] -> [CStmt] -> CStmt
 cDefineCon name params is stmts =
   hang (cCall name params) 2 initializers <+> body
@@ -147,6 +154,9 @@ cDeclareFun ty name params = cStmt decl
 cNamespace :: CIdent -> [CDecl] -> CDecl
 cNamespace nm d =
   "namespace" <+> nm <+> "{" $$ nest 2 (vcat d) $$ "}"
+
+cUsingT :: CIdent -> CType -> CDecl
+cUsingT x t = cStmt ("using" <+> x <+> "=" <+> t)
 
 cUnreachable :: CStmt
 cUnreachable = "__builtin_unreachable();"

--- a/daedalus-vm/src/Daedalus/VM/Backend/C/Names.hs
+++ b/daedalus-vm/src/Daedalus/VM/Backend/C/Names.hs
@@ -154,7 +154,10 @@ selName own l = pref <.> "_" <.> cLabel l
 
 
 cFName :: FName -> CIdent
-cFName f = escDoc ("parse_" <.> pp f)
+cFName f = escDoc ("parser_" <.> pp f)
+
+cFEntryName :: FName -> CIdent
+cFEntryName f = escDoc ("parse" <.> pp f)
 
 --------------------------------------------------------------------------------
 isReserved :: Text -> Bool

--- a/daedalus-vm/src/Daedalus/VM/BorrowAnalysis.hs
+++ b/daedalus-vm/src/Daedalus/VM/BorrowAnalysis.hs
@@ -13,8 +13,6 @@ import Daedalus.Core(Op1(..),Op2(..),Op3(..),OpN(..))
 import Daedalus.VM
 import Daedalus.VM.TypeRep
 
-import Debug.Trace
-
 {-
 * Notes on reference variables:
 
@@ -69,7 +67,7 @@ of basic blocks (point 5)
 
 
 doBorrowAnalysis :: Program -> Program
-doBorrowAnalysis prog = traceShow info $ Program { pModules = annModule <$> pModules prog }
+doBorrowAnalysis prog = Program { pModules = annModule <$> pModules prog }
   where
   info        = borrowAnalysis prog
 

--- a/daedalus-vm/src/Daedalus/VM/BorrowAnalysis.hs
+++ b/daedalus-vm/src/Daedalus/VM/BorrowAnalysis.hs
@@ -418,6 +418,7 @@ modeOp1 op =
     Head                  -> [Borrowed]
     StreamOffset          -> [Borrowed]
     StreamLen             -> [Borrowed]
+    BytesOfStream         -> [Borrowed]
     OneOf {}              -> [Borrowed]
     Neg                   -> [Owned]
     BitNot                -> [Owned]

--- a/daedalus-vm/src/Daedalus/VM/CaptureAnalysis.hs
+++ b/daedalus-vm/src/Daedalus/VM/CaptureAnalysis.hs
@@ -15,12 +15,7 @@ import Daedalus.VM
 
 
 captureAnalysis :: Program -> Program
-captureAnalysis prog =
-  Program { pModules = map annotateModule ms
-          , pEntries = map annotateEntry (pEntries prog)
-          }
-
-
+captureAnalysis prog = Program { pModules = map annotateModule ms }
   where
   ms = pModules prog
 
@@ -47,15 +42,6 @@ captureAnalysis prog =
   ---
 
   annotateModule m = m { mFuns = map annotateFun (mFuns m) }
-  annotateEntry e =
-    let bs   = entryBoot e
-        c    = case foldMap captureInfo bs of
-                 CapturesYes -> Capture
-                 CapturesIf xs
-                   | any (\x -> getCaptures info x == Capture) xs -> Capture
-                   | otherwise -> NoCapture
-
-    in e { entryBoot = annotateBlock c <$> entryBoot e }
 
   annotateFun f = f { vmfCaptures = me
                     , vmfDef = annotateDef me (vmfDef f)

--- a/daedalus-vm/src/Daedalus/VM/Compile/Decl.hs
+++ b/daedalus-vm/src/Daedalus/VM/Compile/Decl.hs
@@ -6,7 +6,6 @@ import qualified Data.Map as Map
 import qualified Data.Text as Text
 import Data.Void(Void)
 
-import Daedalus.Panic(panic)
 import Daedalus.PP(pp)
 
 import qualified Daedalus.Core as Src
@@ -24,54 +23,25 @@ import Daedalus.VM.TailCallJump
 
 
 
-moduleToProgram :: [Src.FName] -> [Module] -> Program
-moduleToProgram entries ms =
+moduleToProgram :: [Module] -> Program
+moduleToProgram ms =
   tailProgram $
   captureAnalysis
-  Program
-    { pModules = map loopAnalysis ms
-    , pEntries = [ compileEntry entry (Src.Call entry []) | entry <- entries ]
-    }
-
-compileEntry :: Src.FName -> Src.Grammar -> Entry
-compileEntry entry pe =
-  Entry { entryLabel = l
-        , entryBoot  = Map.adjust addArgs l b
-        , entryType  = Src.fnameType entry
-        , entryName  = entName
-        }
-  where
-  entName = Text.pack ("parse" ++ show (pp entry))
-
-  addArgs bl = bl { blockArgs = [inpArg] }
-  (l,b) =
-    runC entName (Src.typeOf pe) $
-    do code <- compile pe
-                  Next { onNo  = Just
-                                 do stmt_ $ Say "Branch failed, resuming"
-                                    term  $ Yield
-                       , onYes = Just \v ->
-                                 do stmt_ $ Say "Branch succeeded, resuming"
-                                    stmt_ $ Output v
-                                    term  $ Yield
-                       }
-       pure (setInput (EBlockArg inpArg) >> code)
-
+  Program { pModules = map loopAnalysis ms }
 
 compileModule :: Src.Module -> Module
 compileModule m =
   Module { mName = Src.mName m
          , mImports = Src.mImports m
          , mTypes = Src.mTypes m
-         , mFuns = map compileFFun (Src.mFFuns m) ++
-                   map compileGFun (Src.mGFuns m)
+         , mFuns  = map compileGFun (Src.mGFuns m)
          }
 
 inpArg :: BA
 inpArg = BA 0 (TSem Src.TStream) Borrowed
 
 compileSomeFun ::
-  Bool -> (Maybe a -> C (BlockBuilder Void)) -> Src.Fun a -> VMFun
+  Bool -> (a -> C (BlockBuilder Void)) -> Src.Fun a -> VMFun
 compileSomeFun isPure doBody fun =
   let xs         = Src.fParams fun
       name       = Src.fName fun
@@ -93,7 +63,7 @@ compileSomeFun isPure doBody fun =
       def = case Src.fDef fun of
                Src.Def e    ->
                  VMDef
-                   let body   = foldr setInp (doBody (Just e)) inpArgs
+                   let body   = foldr setInp (doBody e) inpArgs
                        (l,ls) = runC lab (Src.typeOf name)
                                          (foldr getArgC body (zip xs args))
                    in VMFBody { vmfEntry = l
@@ -113,17 +83,11 @@ compileSomeFun isPure doBody fun =
             , vmfPure   = isPure
             , vmfLoop   = False
             , vmfDef    = def
+            , vmfIsEntry = Src.fIsEntry fun
             }
 
 compileFFun :: Src.Fun Src.Expr -> VMFun
-compileFFun = compileSomeFun True \mb ->
-  case mb of
-    Just e -> compileE e Nothing
-    Nothing -> panic "compileFFun" ["XXX: External primitives"]
+compileFFun = compileSomeFun True \e -> compileE e Nothing
 
 compileGFun :: Src.Fun Src.Grammar -> VMFun
-compileGFun = compileSomeFun False \mb ->
-  case mb of
-    Just e -> compile e ret
-    Nothing -> panic "compileGFun" ["XXX: External primitives"]
-
+compileGFun = compileSomeFun False (\e -> compile e ret)

--- a/daedalus-vm/src/Daedalus/VM/Compile/Decl.hs
+++ b/daedalus-vm/src/Daedalus/VM/Compile/Decl.hs
@@ -34,7 +34,8 @@ compileModule m =
   Module { mName = Src.mName m
          , mImports = Src.mImports m
          , mTypes = Src.mTypes m
-         , mFuns  = map compileGFun (Src.mGFuns m)
+         , mFuns  = map compileFFun (Src.mFFuns m)
+                 ++ map compileGFun (Src.mGFuns m)
          }
 
 inpArg :: BA

--- a/daedalus-vm/src/Daedalus/VM/InsertCopy.hs
+++ b/daedalus-vm/src/Daedalus/VM/InsertCopy.hs
@@ -19,11 +19,8 @@ import Daedalus.VM.FreeVars
 
 
 addCopyIs :: Program -> Program
-addCopyIs p = p { pEntries = annEntry  <$> pEntries p
-                , pModules = annModule <$> pModules p
-                }
+addCopyIs p = Program { pModules = annModule <$> pModules p }
   where
-  annEntry e  = e { entryBoot = blockMap (entryBoot e) }
   annModule m = m { mFuns = map annFun (mFuns m) }
   annFun f    = f { vmfDef = annDef (vmfDef f) }
   annDef d    = case d of
@@ -38,10 +35,7 @@ addCopyIs p = p { pEntries = annEntry  <$> pEntries p
 buildRO :: Program -> RO
 buildRO p = foldr addFun initRO [ f | m <- pModules p, f <- mFuns m ]
   where
-  initRO = RO { funMap = Map.empty
-              , labOwn = Map.unions [ blockSig <$> entryBoot entry
-                                                        | entry <- pEntries p ]
-              }
+  initRO = RO { funMap = Map.empty, labOwn = Map.empty }
 
   addFun f i =
     case vmfDef f of

--- a/daedalus-vm/src/Daedalus/VM/RefCountSane.hs
+++ b/daedalus-vm/src/Daedalus/VM/RefCountSane.hs
@@ -29,11 +29,9 @@ checkProgram prog =
     Right _  -> Nothing
     Left err -> Just err
   where
-  check = do mapM_ checkModule (pModules prog)
-             mapM_ checkEntry  (pEntries prog)
+  check = mapM_ checkModule (pModules prog)
 
   checkModule = mapM_ checkVMFun . mFuns
-  checkEntry  = checkBlocks . entryBoot
   checkVMFun f = case vmfDef f of
                    VMDef b -> checkBlocks (vmfBlocks b)
                    VMExtern {} -> pure ()

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -242,11 +242,11 @@ doToCore opts mm =
 
 doToVM :: Options -> ModuleName -> Daedalus VM.Program
 doToVM opts mm =
-  do ents <- doToCore opts mm
+  do _ <- doToCore opts mm
      passVM specMod
      m <- ddlGetAST specMod astVM
      let addMM = VM.addCopyIs . VM.doBorrowAnalysis
-     pure $ addMM $ VM.moduleToProgram ents [m]
+     pure $ addMM $ VM.moduleToProgram [m]
 
 
 parseEntries :: Options -> ModuleName -> [(ModuleName,Ident)]

--- a/exe/c-template/main.cpp
+++ b/exe/c-template/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
   DDL::ParseError err;
   std::vector<DDL::ResultOf::parseMain> out;
   auto start = std::chrono::high_resolution_clock::now();
-  parseMain(i,err,out);
+  parseMain(err,out,i);
   auto end  = std::chrono::high_resolution_clock::now();
   auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
             .count();

--- a/rts-c/ddl/input.h
+++ b/rts-c/ddl/input.h
@@ -145,6 +145,9 @@ public:
   }
 
   char* borrowBytes() { return (char*) bytes.borrowData() + offset.rep(); }
+
+  Array<UInt<8>> borrowByteArray() { return bytes; }
+  Array<UInt<8>> getByteArray() { bytes.copy(); return bytes; }
 };
 
 

--- a/rts-c/ddl/parser.h
+++ b/rts-c/ddl/parser.h
@@ -27,7 +27,7 @@ class ParserState {
 public:
   ParserState() : fail_offset(0) {}
 
-  Size getFailOffest() { return fail_offset; }
+  Size getFailOffset() { return fail_offset; }
 
   // All alternatives failed.   Free the stack and return the
   // offset of the best error we computed.

--- a/rts-c/ddl/parser.h
+++ b/rts-c/ddl/parser.h
@@ -27,6 +27,8 @@ class ParserState {
 public:
   ParserState() : fail_offset(0) {}
 
+  Size getFailOffest() { return fail_offset; }
+
   // All alternatives failed.   Free the stack and return the
   // offset of the best error we computed.
   Size finalYield() {

--- a/src/Daedalus/AST.hs
+++ b/src/Daedalus/AST.hs
@@ -285,6 +285,7 @@ data BinOp = Add | Sub | Mul | Div | Mod
 data UniOp = Not | Neg | Concat | BitwiseComplement
            | WordToFloat | WordToDouble
            | IsNaN | IsInfinite | IsDenormalized | IsNegativeZero
+           | BytesOfStream
   deriving (Show, Eq)
 
 data Selector = SelStruct (Located Label)
@@ -482,6 +483,7 @@ instance PP UniOp where
       IsInfinite      -> "isInfinit"
       IsDenormalized  -> "isDenormalized"
       IsNegativeZero  -> "isNegativeZero"
+      BytesOfStream   -> "bytesAOfStream"
 
 instance PP Selector where
   pp sel = case sel of

--- a/src/Daedalus/CompileHS.hs
+++ b/src/Daedalus/CompileHS.hs
@@ -626,6 +626,8 @@ hsValue env tc =
         IsInfinite        -> "HS.isInfinite" `Ap` hsValue env v
         IsDenormalized    -> "HS.isDenormalized" `Ap` hsValue env v
         IsNegativeZero    -> "HS.isNegativeZero" `Ap` hsValue env v
+        BytesOfStream     ->
+            "Vector.vecFromRep" `Ap` ("RTS.inputBytes" `Ap` hsValue env v)
 
     TCVar x -> hsValName env NameUse (tcName x)
     TCCall f ts as -> hsApp env f ts as

--- a/src/Daedalus/DDL2Core.hs
+++ b/src/Daedalus/DDL2Core.hs
@@ -1048,6 +1048,7 @@ fromExpr expr =
                 TC.IsInfinite     -> eIsInfinite e
                 TC.IsDenormalized -> eIsDenormalized e
                 TC.IsNegativeZero -> eIsNegativeZero e
+                TC.BytesOfStream  -> bytesOfStream e
 
     TC.TCBinOp op v1 v2 _ ->
       do e1 <- fromExpr v1

--- a/src/Daedalus/Driver.hs
+++ b/src/Daedalus/Driver.hs
@@ -722,6 +722,7 @@ passSpecialize tgt roots =
              mo = TCModule
                     { tcModuleName = tgt
                     , tcModuleImports = []
+                    , tcEntries = rootNames
                     , tcModuleTypes = tdecls
                     , tcModuleDecls = ds
                     }

--- a/src/Daedalus/Interp.hs
+++ b/src/Daedalus/Interp.hs
@@ -146,6 +146,7 @@ evalUniOp op =
     IsInfinite        -> vIsInfinite
     IsDenormalized    -> vIsDenormalized
     IsNegativeZero    -> vIsNegativeZero
+    BytesOfStream     -> vBytesOfStream
 
 
 

--- a/src/Daedalus/Parser/Grammar.y
+++ b/src/Daedalus/Parser/Grammar.y
@@ -137,6 +137,7 @@ import Daedalus.Parser.Monad
   'Take'      { Lexeme { lexemeRange = $$, lexemeToken = KWTake } }
   'Drop'      { Lexeme { lexemeRange = $$, lexemeToken = KWDrop } }
   'arrayStream' { Lexeme { lexemeRange = $$, lexemeToken = KWArrayStream } }
+  'bytesOfStream' { Lexeme { lexemeRange = $$, lexemeToken = KWBytesOfStream} }
   'nothing'   { Lexeme { lexemeRange = $$, lexemeToken = KWNothing } }
   'just'      { Lexeme { lexemeRange = $$, lexemeToken = KWJust } }
   'length'    { Lexeme { lexemeRange = $$, lexemeToken = KWArrayLength } }
@@ -310,6 +311,7 @@ label                                    :: { Located Label }
   | 'rangeDown'                             { mkLabel ($1,"rangeDown") }
   | 'try'                                   { mkLabel ($1,"try") }
   | 'arrayStream'                           { mkLabel ($1,"arrayStream") }
+  | 'bytesOfStream'                         { mkLabel ($1,"bytesOfStream") }
   | 'Fail'                                  { mkLabel ($1,"Fail") }
 
 expr                                     :: { Expr }
@@ -436,6 +438,7 @@ call_expr                                :: { Expr }
                                               (at ($1,$2) (ELiteral (LBytes "array")))
                                               $2) }
   | 'arrayStream' aexpr aexpr   { at ($1,$3)(EBinOp ArrayStream $2 $3)}
+  | 'bytesOfStream' aexpr       { at ($1,$2) (EUniOp BytesOfStream $2) }
 
   | 'wordToFloat' aexpr         { at ($1,$2) (EUniOp WordToFloat $2) }
   | 'wordToDouble' aexpr        { at ($1,$2) (EUniOp WordToDouble $2) }

--- a/src/Daedalus/Parser/Lexer.x
+++ b/src/Daedalus/Parser/Lexer.x
@@ -155,6 +155,7 @@ $ws+        ;
 "Take"      { lexeme KWTake }
 "Drop"      { lexeme KWDrop }
 "arrayStream" { lexeme KWArrayStream }
+"bytesOfStream" { lexeme KWBytesOfStream }
 
 "Index"     { lexeme KWArrayIndex }
 "concat"    { lexeme KWConcat }

--- a/src/Daedalus/Parser/Tokens.hs
+++ b/src/Daedalus/Parser/Tokens.hs
@@ -123,6 +123,7 @@ data Token =
   | KWNothing
   | KWDef
   | KWArrayStream
+  | KWBytesOfStream
   | KWFail
   | KWCase
   | KWBitData

--- a/src/Daedalus/ParserGen/Compile.hs
+++ b/src/Daedalus/ParserGen/Compile.hs
@@ -376,6 +376,7 @@ allocTCModule n _tc@(TCModule{..}) =
       annotTCModule =
         TCModule
         { tcModuleName = tcModuleName
+        , tcEntries = []
         , tcModuleImports = tcModuleImports
         , tcModuleTypes = tcModuleTypes
         , tcModuleDecls = reverse atc
@@ -421,6 +422,7 @@ allocStates decls =
             NonRec d ->
               let uniModule =
                     TCModule { tcModuleName = tcModuleName
+                             , tcEntries = []
                              , tcModuleImports = tcModuleImports
                              , tcModuleTypes = tcModuleTypes
                              , tcModuleDecls = [ NonRec d ]
@@ -433,6 +435,7 @@ allocStates decls =
         f localM decl =
           let uniModule =
                 TCModule { tcModuleName = tcModuleName
+                         , tcEntries = []
                          , tcModuleImports = tcModuleImports
                          , tcModuleTypes = tcModuleTypes
                          , tcModuleDecls = [ NonRec decl ]

--- a/src/Daedalus/Type.hs
+++ b/src/Daedalus/Type.hs
@@ -446,6 +446,10 @@ inferExpr expr =
           do addConstraint expr (FloatingType t)
              pure (exprAt expr (TCUniOp IsNegativeZero e1'), tBool)
 
+        BytesOfStream ->
+          liftValAppPure expr [e] \ ~[(e1',t)] ->
+            pure (exprAt expr (TCUniOp BytesOfStream e1'), tArray tByte)
+
 
     ETriOp op e1 e2 e3 ->
       case op of

--- a/src/Daedalus/Type.hs
+++ b/src/Daedalus/Type.hs
@@ -52,6 +52,7 @@ inferRules m =
       [] -> pure TCModule
                    { tcModuleName = moduleName m
                    , tcModuleImports = moduleImports m
+                   , tcEntries = []
                    , tcModuleTypes = map sccToRec
                                    $ stronglyConnComp
                                    $ map getDeps

--- a/src/Daedalus/Type/AST.hs
+++ b/src/Daedalus/Type/AST.hs
@@ -1036,6 +1036,7 @@ instance TypeOf (TCF a k) where
           IsInfinite {}     -> tBool
           IsDenormalized {} -> tBool
           IsNegativeZero {} -> tBool
+          BytesOfStream {}  -> tArray tByte
 
 
       TCSelStruct _ _ t  -> t

--- a/src/Daedalus/Type/AST.hs
+++ b/src/Daedalus/Type/AST.hs
@@ -344,6 +344,7 @@ data TCDeclDef a k = ExternDecl Type | Defined (TC a k)
 -- | A module consists of a collection of types and a collection of decls.
 data TCModule a = TCModule { tcModuleName    :: ModuleName
                            , tcModuleImports :: [ Located ModuleName ]
+                           , tcEntries       :: ![ Name ]
                            , tcModuleTypes   :: [ Rec TCTyDecl ]
                            , tcModuleDecls   :: [ Rec (TCDecl a) ]
                            } deriving Show

--- a/syntax-highlight/daedalus.vim
+++ b/syntax-highlight/daedalus.vim
@@ -32,7 +32,7 @@ syn keyword ddlKeywordFun   Offset SetStream GetStream Take Drop
 syn keyword ddlKeywordConst true false
 syn keyword ddlKeywordConst nothing just
 syn keyword ddlKeywordConst empty
-syn keyword ddlKeywordFun   arrayStream
+syn keyword ddlKeywordFun   arrayStream bytesOfStream
 syn keyword ddlKeywordFun   insert Insert Lookup
 syn keyword ddlKeywordFun   Index length concat rangeUp rangeDown
 syn keyword ddlKeywordFun   try


### PR DESCRIPTION
A primitive for accessing the bytes of an array.  This is more efficient that doing `Many UInt8` and can be done pure (i.e., not as a parser)