### PR TITLE
Determinization support grammar calls with args

### DIFF
--- a/tests/determinize/Det005.test.stdout
+++ b/tests/determinize/Det005.test.stdout
@@ -35,13 +35,13 @@ proc SimpleEOL_() : () =
   -- DETERMINIZE 1 Fully
   do _x0 <- match1 { ... }
      case _x0 of
-       10 ->
-         -- ./Det005.ddl:9:45--9:47
-         pure ()
        13 ->
          -- ./Det005.ddl:9:31--9:38
          -- ./Det005.ddl:9:36--9:38
          match1_ $lf()
+       10 ->
+         -- ./Det005.ddl:9:45--9:47
+         pure ()
        _ ->
          fail_sys @()
  
@@ -51,11 +51,6 @@ proc EOL_() : () =
   -- DETERMINIZE 1
   do _x0 <- match1 { ... }
      case _x0 of
-       10 ->
-         -- ./Det005.ddl:10:29--10:37
-         -- ./Det005.ddl:9:29--9:47
-         -- ./Det005.ddl:9:45--9:47
-         pure ()
        13 ->
          -- OR RECONSTRUCTION
          try
@@ -67,6 +62,11 @@ proc EOL_() : () =
          orelse
            -- ./Det005.ddl:10:42--10:44
            pure ()
+       10 ->
+         -- ./Det005.ddl:10:29--10:37
+         -- ./Det005.ddl:9:29--9:47
+         -- ./Det005.ddl:9:45--9:47
+         pure ()
        _ ->
          fail_sys @()
  
@@ -95,30 +95,10 @@ proc AnyWS_() : () =
          -- ./Det005.ddl:12:29--12:48
          -- ./Det005.ddl:12:29--12:37
          pure ()
-       10 ->
-         -- ./Det005.ddl:12:53--12:55
-         -- ./Det005.ddl:10:29--10:44
-         -- ./Det005.ddl:10:29--10:37
-         -- ./Det005.ddl:9:29--9:47
-         -- ./Det005.ddl:9:45--9:47
-         pure ()
        12 ->
          -- ./Det005.ddl:12:29--12:48
          -- ./Det005.ddl:12:29--12:37
          pure ()
-       13 ->
-         -- OR RECONSTRUCTION
-         -- ./Det005.ddl:12:53--12:55
-         -- ./Det005.ddl:10:29--10:44
-         try
-           -- ./Det005.ddl:10:29--10:37
-           -- ./Det005.ddl:9:29--9:47
-           -- ./Det005.ddl:9:31--9:38
-           -- ./Det005.ddl:9:36--9:38
-           match1_ $lf()
-         orelse
-           -- ./Det005.ddl:10:42--10:44
-           pure ()
        32 ->
          -- ./Det005.ddl:12:29--12:48
          -- ./Det005.ddl:12:29--12:37
@@ -132,6 +112,26 @@ proc AnyWS_() : () =
             Many_24()
             -- ./Det005.ddl:11:65--11:67
             EOL_()
+       13 ->
+         -- OR RECONSTRUCTION
+         -- ./Det005.ddl:12:53--12:55
+         -- ./Det005.ddl:10:29--10:44
+         try
+           -- ./Det005.ddl:10:29--10:37
+           -- ./Det005.ddl:9:29--9:47
+           -- ./Det005.ddl:9:31--9:38
+           -- ./Det005.ddl:9:36--9:38
+           match1_ $lf()
+         orelse
+           -- ./Det005.ddl:10:42--10:44
+           pure ()
+       10 ->
+         -- ./Det005.ddl:12:53--12:55
+         -- ./Det005.ddl:10:29--10:44
+         -- ./Det005.ddl:10:29--10:37
+         -- ./Det005.ddl:9:29--9:47
+         -- ./Det005.ddl:9:45--9:47
+         pure ()
        _ ->
          fail_sys @()
  

--- a/tests/determinize/Det009.ddl
+++ b/tests/determinize/Det009.ddl
@@ -1,0 +1,53 @@
+-- testing grammar call with parameters from JpegBasics.ddl
+
+def Main = block
+  @e = Endian
+  IFDEntry e
+
+def Endian = First
+  LE = @Match "II"
+  BE = @Match "MM"
+
+def IFDEntry e = First
+  imageWidth  = NumericTag e 0x100
+  imageHeight = NumericTag e 0x101
+  -- bits per sample
+  compression = NumericTag e 0x103    -- 1 = none, 6 = jpeg
+  photometricInterpretation = NumericTag e 0x106
+
+  samplesPerPixel = NumericTag e 0x115
+  rowsPerStrip    = NumericTag e 0x116
+
+  unknown     = IFDUnknown e
+
+def Tag e x = Word16 e == x is true
+def NumericTag e x = block
+  Tag e x
+  Unsgned e
+
+def Unsgned e = block
+  let format = Word16 e
+  -- let items  = Word32 e
+  -- items == 1 is true
+  -- case format of
+  --   1 -> block $$ = UInt8    as uint 64; Many 3 UInt8
+  --   3 -> block $$ = Word16 e as uint 64; Many 2 UInt8
+  --   4 -> Word32 e as uint 64
+
+def IFDUnknown e = block
+  tag    = Word16 e
+  format = Word16 e as uint 64
+  -- items  = Word32 e as uint 64
+  -- data   = Word32 e
+
+
+--------------------------------------------------------------------------------
+-- Misc. utilities
+
+def jn (e : Endian) x y =
+  case e of
+    BE -> x # y
+    LE -> y # x
+
+def Word16 e = jn e UInt8 UInt8
+def Word32 e = jn e (Word16 e) (Word16 e)

--- a/tests/determinize/Det009.ddl.stdout
+++ b/tests/determinize/Det009.ddl.stdout
@@ -1,0 +1,139 @@
+module Det009
+ 
+--- Imports:
+ 
+--- Type defs:
+type Det009.Endian = Choose { BE: {}
+                            ; LE: {}
+                            }
+ 
+type Det009.IFDUnknown = { tag: uint 16
+                         ; format: uint 64
+                         }
+ 
+type Det009.IFDEntry = Choose { unknown: Det009.IFDUnknown
+                              ; samplesPerPixel: {}
+                              ; rowsPerStrip: {}
+                              ; photometricInterpretation: {}
+                              ; imageWidth: {}
+                              ; imageHeight: {}
+                              ; compression: {}
+                              }
+ 
+--- Rules:
+ 
+Det009.Endian : Grammar Det009.Endian =
+  Choose biased
+    { {- LE -} do (_26 : {}) <- @MatchBytes "II"
+                  pure {LE: _26}
+    | {- BE -} do (_27 : {}) <- @MatchBytes "MM"
+                  pure {BE: _27}
+    }
+ 
+Det009.Word16_ : Grammar {} =
+  do @Match UInt8
+     @Match UInt8
+ 
+Det009.Unsgned (e : Det009.Endian) : Grammar {} =
+  Det009.Word16_
+ 
+Det009.jn ?a0 ?a1 ?a2 (?a1 + ?a0 = ?a2) (?a0 + ?a1 = ?a2) (e : Det009.Endian) (x : uint ?a0) (y : uint ?a1) : uint ?a2 =
+  case e is
+    { {| BE = _ |} -> x # y
+    ; {| LE = _ |} -> y # x
+    }
+ 
+Det009.Word16 (e : Det009.Endian) : Grammar (uint 16) =
+  do (_28 : uint 8) <- Match UInt8
+     (_29 : uint 8) <- Match UInt8
+     pure (Det009.jn 8 8 16 e _28 _29)
+ 
+Det009.Tag_ (e : Det009.Endian) (x : uint 16) : Grammar {} =
+  do (_31 : bool) <- do (_30 : uint 16) <- Det009.Word16 e
+                        pure (_30 == x)
+     case _31 is
+       { true -> pure {}
+       }
+ 
+Det009.NumericTag (e : Det009.Endian) (x : uint 16) : Grammar {} =
+  do Det009.Tag_ e x
+     ($$ : {}) <- Det009.Unsgned e
+     pure $$
+ 
+Det009.IFDUnknown (e : Det009.Endian) : Grammar Det009.IFDUnknown =
+  do (tag : uint 16) <- Det009.Word16 e
+     (format : uint 64) <- do (_33 : uint 16) <- Det009.Word16 e
+                              pure (_33 as uint 64)
+     pure {tag = tag,
+           format = format}
+ 
+Det009.IFDEntry (e : Det009.Endian) : Grammar Det009.IFDEntry =
+  Choose biased
+    { {- imageWidth -} do (_34 : {}) <- Det009.NumericTag e 0x100
+                          pure {imageWidth: _34}
+    | {- imageHeight -} do (_35 : {}) <- Det009.NumericTag e 0x101
+                           pure {imageHeight: _35}
+    | {- compression -} do (_36 : {}) <- Det009.NumericTag e 0x103
+                           pure {compression: _36}
+    | {- photometricInterpretation -} do (_37 : {}) <- Det009.NumericTag e 0x106
+                                         pure {photometricInterpretation: _37}
+    | {- samplesPerPixel -} do (_38 : {}) <- Det009.NumericTag e 0x115
+                               pure {samplesPerPixel: _38}
+    | {- rowsPerStrip -} do (_39 : {}) <- Det009.NumericTag e 0x116
+                            pure {rowsPerStrip: _39}
+    | {- unknown -} do (_40 : Det009.IFDUnknown) <- Det009.IFDUnknown e
+                       pure {unknown: _40}
+    }
+ 
+Det009.Main : Grammar Det009.IFDEntry =
+  do (e : Det009.Endian) <- Det009.Endian
+     ($$ : Det009.IFDEntry) <- Det009.IFDEntry e
+     pure $$
+ 
+Det009.Tag (e : Det009.Endian) (x : uint 16) : Grammar {} =
+  do (_31 : bool) <- do (_30 : uint 16) <- Det009.Word16 e
+                        pure (_30 == x)
+     case _31 is
+       { true -> pure {}
+       }
+ 
+Det009.Word32 (e : Det009.Endian) : Grammar (uint 32) =
+  do (_42 : uint 16) <- Det009.Word16 e
+     (_43 : uint 16) <- Det009.Word16 e
+     pure (Det009.jn 16 16 32 e _42 _43)
+ 
+Det009.Endian_ : Grammar {} =
+  Choose biased
+    { {- LE -} @MatchBytes "II"
+    | {- BE -} @MatchBytes "MM"
+    }
+ 
+Det009.Unsgned_ : Grammar {} =
+  Det009.Word16_
+ 
+Det009.NumericTag_ (e : Det009.Endian) (x : uint 16) : Grammar {} =
+  do Det009.Tag_ e x
+     Det009.Unsgned_
+ 
+Det009.IFDUnknown_ : Grammar {} =
+  do Det009.Word16_
+     Det009.Word16_
+ 
+Det009.IFDEntry_ (e : Det009.Endian) : Grammar {} =
+  Choose biased
+    { {- imageWidth -} Det009.NumericTag_ e 0x100
+    | {- imageHeight -} Det009.NumericTag_ e 0x101
+    | {- compression -} Det009.NumericTag_ e 0x103
+    | {- photometricInterpretation -} Det009.NumericTag_ e 0x106
+    | {- samplesPerPixel -} Det009.NumericTag_ e 0x115
+    | {- rowsPerStrip -} Det009.NumericTag_ e 0x116
+    | {- unknown -} Det009.IFDUnknown_
+    }
+ 
+Det009.Main_ : Grammar {} =
+  do (e : Det009.Endian) <- Det009.Endian
+     Det009.IFDEntry_ e
+ 
+Det009.Word32_ : Grammar {} =
+  do Det009.Word16_
+     Det009.Word16_

--- a/tests/determinize/Det009.test
+++ b/tests/determinize/Det009.test
@@ -1,0 +1,4 @@
+dump
+Det009.ddl
+--core
+--determinize

--- a/tests/determinize/Det009.test.stdout
+++ b/tests/determinize/Det009.test.stdout
@@ -1,0 +1,447 @@
+module DaedalusMain where
+ 
+ 
+type Endian =
+  union
+    BE : ()
+    LE : ()
+ 
+type IFDUnknown =
+  struct
+    tag : Word 16
+    format : Word 64
+ 
+type IFDEntry =
+  union
+    unknown : IFDUnknown
+    samplesPerPixel : ()
+    rowsPerStrip : ()
+    photometricInterpretation : ()
+    imageWidth : ()
+    imageHeight : ()
+    compression : ()
+ 
+-------------
+ 
+-- ./Det009.ddl:47:1--52:3
+func jn_71(e : Endian, x : Word 8, y : Word 8) : Word 16 =
+  case e of
+    BE ->
+      x # y
+    LE ->
+      y # x
+ 
+-- ./Det009.ddl:7:1--11:3
+proc Endian() : Endian =
+  -- ./Det009.ddl:7:14--11:3
+  -- DETERMINIZE 1 Fully
+  do _x0 <- match1 { ... }
+     case _x0 of
+       73 ->
+         -- ./Det009.ddl:8:3--8:18
+         -- LE
+         -- ./Det009.ddl:8:3--8:18
+         do _26 <- -- ./Det009.ddl:8:9--8:18
+                   match_ "I"
+            -- ./Det009.ddl:8:3--8:18
+            pure (tag LE @Endian _26)
+       77 ->
+         -- ./Det009.ddl:9:3--9:18
+         -- BE
+         -- ./Det009.ddl:9:3--9:18
+         do _27 <- -- ./Det009.ddl:9:9--9:18
+                   match_ "M"
+            -- ./Det009.ddl:9:3--9:18
+            pure (tag BE @Endian _27)
+       _ ->
+         fail_sys @Endian
+ 
+-- ./Det009.ddl:52:1--52:31
+proc Word16_() : () =
+  -- ./Det009.ddl:52:21--52:31
+  do -- ./Det009.ddl:52:21--52:25
+     match1_ { ... }
+     -- ./Det009.ddl:52:27--52:31
+     match1_ { ... }
+ 
+-- ./Det009.ddl:28:1--37:3
+proc Unsgned(e : Endian) : () =
+  -- ./Det009.ddl:29:16--29:23
+  Word16_()
+ 
+-- ./Det009.ddl:52:1--52:31
+proc Word16(e : Endian) : Word 16 =
+  -- ./Det009.ddl:52:21--52:31
+  do _28 <- -- ./Det009.ddl:52:21--52:25
+            match1 { ... }
+     -- ./Det009.ddl:52:27--52:31
+     _29 <- -- ./Det009.ddl:52:27--52:31
+            match1 { ... }
+     -- ./Det009.ddl:52:16--52:31
+     pure jn_71(e, _28, _29)
+ 
+-- ./Det009.ddl:23:1--23:35
+proc Tag_(e : Endian, x : Word 16) : () =
+  -- ./Det009.ddl:23:15--23:35
+  -- ./Det009.ddl:23:15--23:27
+  do _30 <- -- ./Det009.ddl:23:15--23:22
+            Word16(e)
+     -- ./Det009.ddl:23:15--23:27
+     let _31 = _30 == x
+     -- ./Det009.ddl:23:15--23:35
+     case _31 of
+       True ->
+         -- ./Det009.ddl:23:15--23:35
+         pure ()
+       False ->
+         fail_sys @() "Pattern match failure"
+ 
+-- ./Det009.ddl:24:1--28:3
+proc NumericTag(e : Endian, x : Word 16) : () =
+  -- ./Det009.ddl:25:3--26:11
+  do -- ./Det009.ddl:25:3--25:9
+     Tag_(e, x)
+     -- ./Det009.ddl:26:3--26:11
+     -- ./Det009.ddl:26:3--26:11
+     Unsgned(e)
+ 
+-- ./Det009.ddl:37:1--47:3
+proc IFDUnknown(e : Endian) : IFDUnknown =
+  -- ./Det009.ddl:38:3--47:3
+  do tag <- -- ./Det009.ddl:38:12--38:19
+            Word16(e)
+     -- ./Det009.ddl:39:3--47:3
+     -- ./Det009.ddl:39:12--39:30
+     _33 <- -- ./Det009.ddl:39:12--39:19
+            Word16(e)
+     -- ./Det009.ddl:39:12--39:30
+     let format = cast @(Word 64) _33
+     -- ./Det009.ddl:37:20--47:3
+     pure IFDUnknown {tag = tag, format = format}
+ 
+-- ./Det009.ddl:11:1--23:3
+proc IFDEntry(e : Endian) : IFDEntry =
+  -- ./Det009.ddl:11:18--23:3
+  -- DETERMINIZE 2
+  do _x0 <- match1 { ... }
+     _x1 <- match1 { ... }
+     -- OR RECONSTRUCTION
+     try
+       -- ./Det009.ddl:12:3--12:34
+       -- imageWidth
+       -- ./Det009.ddl:12:3--12:34
+       do let e = e
+          let x = 256 @(Word 16)
+          let e = e
+          let x = x
+          let e = e
+          let _28 = _x0
+          let _29 = _x1
+          let _30 = jn_71(e, _28, _29)
+          let _31 = _30 == x
+          -- DETCALL 
+          -- ./Det009.ddl:12:17--12:34
+          -- ./Det009.ddl:25:3--26:11
+          -- ./Det009.ddl:23:15--23:27
+          -- ./Det009.ddl:23:15--23:27
+          -- ./Det009.ddl:23:15--23:35
+          -- ./Det009.ddl:25:3--25:9
+          -- DETCALL 
+          -- ./Det009.ddl:52:16--52:31
+          -- ./Det009.ddl:52:21--52:25
+          -- ./Det009.ddl:52:21--52:31
+          -- ./Det009.ddl:23:15--23:22
+          -- DETCALL 
+          -- ./Det009.ddl:52:27--52:31
+          -- ./Det009.ddl:52:27--52:31
+          -- ./Det009.ddl:23:15--23:35
+          case _31 of
+            True ->
+              -- ./Det009.ddl:23:15--23:35
+              pure ()
+            False ->
+              fail_sys @() "Pattern match failure"
+          _34 <- -- DETCALL 
+                 -- ./Det009.ddl:12:17--12:34
+                 -- ./Det009.ddl:25:3--26:11
+                 -- ./Det009.ddl:26:3--26:11
+                 -- ./Det009.ddl:26:3--26:11
+                 Unsgned(e)
+          -- ./Det009.ddl:12:3--12:34
+          pure (tag imageWidth @IFDEntry _34)
+     orelse
+       -- OR RECONSTRUCTION
+       else try
+         -- ./Det009.ddl:13:3--13:34
+         -- imageHeight
+         -- ./Det009.ddl:13:3--13:34
+         do let e = e
+            let x = 257 @(Word 16)
+            let e = e
+            let x = x
+            let e = e
+            let _28 = _x0
+            let _29 = _x1
+            let _30 = jn_71(e, _28, _29)
+            let _31 = _30 == x
+            -- DETCALL 
+            -- ./Det009.ddl:13:17--13:34
+            -- ./Det009.ddl:25:3--26:11
+            -- ./Det009.ddl:23:15--23:27
+            -- ./Det009.ddl:23:15--23:27
+            -- ./Det009.ddl:23:15--23:35
+            -- ./Det009.ddl:25:3--25:9
+            -- DETCALL 
+            -- ./Det009.ddl:52:16--52:31
+            -- ./Det009.ddl:52:21--52:25
+            -- ./Det009.ddl:52:21--52:31
+            -- ./Det009.ddl:23:15--23:22
+            -- DETCALL 
+            -- ./Det009.ddl:52:27--52:31
+            -- ./Det009.ddl:52:27--52:31
+            -- ./Det009.ddl:23:15--23:35
+            case _31 of
+              True ->
+                -- ./Det009.ddl:23:15--23:35
+                pure ()
+              False ->
+                fail_sys @() "Pattern match failure"
+            _35 <- -- DETCALL 
+                   -- ./Det009.ddl:13:17--13:34
+                   -- ./Det009.ddl:25:3--26:11
+                   -- ./Det009.ddl:26:3--26:11
+                   -- ./Det009.ddl:26:3--26:11
+                   Unsgned(e)
+            -- ./Det009.ddl:13:3--13:34
+            pure (tag imageHeight @IFDEntry _35)
+       orelse
+         -- OR RECONSTRUCTION
+         else try
+           -- ./Det009.ddl:15:3--15:34
+           -- compression
+           -- ./Det009.ddl:15:3--15:34
+           do let e = e
+              let x = 259 @(Word 16)
+              let e = e
+              let x = x
+              let e = e
+              let _28 = _x0
+              let _29 = _x1
+              let _30 = jn_71(e, _28, _29)
+              let _31 = _30 == x
+              -- DETCALL 
+              -- ./Det009.ddl:15:17--15:34
+              -- ./Det009.ddl:25:3--26:11
+              -- ./Det009.ddl:23:15--23:27
+              -- ./Det009.ddl:23:15--23:27
+              -- ./Det009.ddl:23:15--23:35
+              -- ./Det009.ddl:25:3--25:9
+              -- DETCALL 
+              -- ./Det009.ddl:52:16--52:31
+              -- ./Det009.ddl:52:21--52:25
+              -- ./Det009.ddl:52:21--52:31
+              -- ./Det009.ddl:23:15--23:22
+              -- DETCALL 
+              -- ./Det009.ddl:52:27--52:31
+              -- ./Det009.ddl:52:27--52:31
+              -- ./Det009.ddl:23:15--23:35
+              case _31 of
+                True ->
+                  -- ./Det009.ddl:23:15--23:35
+                  pure ()
+                False ->
+                  fail_sys @() "Pattern match failure"
+              _36 <- -- DETCALL 
+                     -- ./Det009.ddl:15:17--15:34
+                     -- ./Det009.ddl:25:3--26:11
+                     -- ./Det009.ddl:26:3--26:11
+                     -- ./Det009.ddl:26:3--26:11
+                     Unsgned(e)
+              -- ./Det009.ddl:15:3--15:34
+              pure (tag compression @IFDEntry _36)
+         orelse
+           -- OR RECONSTRUCTION
+           else try
+             -- ./Det009.ddl:16:3--16:48
+             -- photometricInterpretation
+             -- ./Det009.ddl:16:3--16:48
+             do let e = e
+                let x = 262 @(Word 16)
+                let e = e
+                let x = x
+                let e = e
+                let _28 = _x0
+                let _29 = _x1
+                let _30 = jn_71(e, _28, _29)
+                let _31 = _30 == x
+                -- DETCALL 
+                -- ./Det009.ddl:16:31--16:48
+                -- ./Det009.ddl:25:3--26:11
+                -- ./Det009.ddl:23:15--23:27
+                -- ./Det009.ddl:23:15--23:27
+                -- ./Det009.ddl:23:15--23:35
+                -- ./Det009.ddl:25:3--25:9
+                -- DETCALL 
+                -- ./Det009.ddl:52:16--52:31
+                -- ./Det009.ddl:52:21--52:25
+                -- ./Det009.ddl:52:21--52:31
+                -- ./Det009.ddl:23:15--23:22
+                -- DETCALL 
+                -- ./Det009.ddl:52:27--52:31
+                -- ./Det009.ddl:52:27--52:31
+                -- ./Det009.ddl:23:15--23:35
+                case _31 of
+                  True ->
+                    -- ./Det009.ddl:23:15--23:35
+                    pure ()
+                  False ->
+                    fail_sys @() "Pattern match failure"
+                _37 <- -- DETCALL 
+                       -- ./Det009.ddl:16:31--16:48
+                       -- ./Det009.ddl:25:3--26:11
+                       -- ./Det009.ddl:26:3--26:11
+                       -- ./Det009.ddl:26:3--26:11
+                       Unsgned(e)
+                -- ./Det009.ddl:16:3--16:48
+                pure (tag photometricInterpretation @IFDEntry _37)
+           orelse
+             -- OR RECONSTRUCTION
+             else try
+               -- ./Det009.ddl:18:3--18:38
+               -- samplesPerPixel
+               -- ./Det009.ddl:18:3--18:38
+               do let e = e
+                  let x = 277 @(Word 16)
+                  let e = e
+                  let x = x
+                  let e = e
+                  let _28 = _x0
+                  let _29 = _x1
+                  let _30 = jn_71(e, _28, _29)
+                  let _31 = _30 == x
+                  -- DETCALL 
+                  -- ./Det009.ddl:18:21--18:38
+                  -- ./Det009.ddl:25:3--26:11
+                  -- ./Det009.ddl:23:15--23:27
+                  -- ./Det009.ddl:23:15--23:27
+                  -- ./Det009.ddl:23:15--23:35
+                  -- ./Det009.ddl:25:3--25:9
+                  -- DETCALL 
+                  -- ./Det009.ddl:52:16--52:31
+                  -- ./Det009.ddl:52:21--52:25
+                  -- ./Det009.ddl:52:21--52:31
+                  -- ./Det009.ddl:23:15--23:22
+                  -- DETCALL 
+                  -- ./Det009.ddl:52:27--52:31
+                  -- ./Det009.ddl:52:27--52:31
+                  -- ./Det009.ddl:23:15--23:35
+                  case _31 of
+                    True ->
+                      -- ./Det009.ddl:23:15--23:35
+                      pure ()
+                    False ->
+                      fail_sys @() "Pattern match failure"
+                  _38 <- -- DETCALL 
+                         -- ./Det009.ddl:18:21--18:38
+                         -- ./Det009.ddl:25:3--26:11
+                         -- ./Det009.ddl:26:3--26:11
+                         -- ./Det009.ddl:26:3--26:11
+                         Unsgned(e)
+                  -- ./Det009.ddl:18:3--18:38
+                  pure (tag samplesPerPixel @IFDEntry _38)
+             orelse
+               -- OR RECONSTRUCTION
+               else try
+                 -- ./Det009.ddl:19:3--19:38
+                 -- rowsPerStrip
+                 -- ./Det009.ddl:19:3--19:38
+                 do let e = e
+                    let x = 278 @(Word 16)
+                    let e = e
+                    let x = x
+                    let e = e
+                    let _28 = _x0
+                    let _29 = _x1
+                    let _30 = jn_71(e, _28, _29)
+                    let _31 = _30 == x
+                    -- DETCALL 
+                    -- ./Det009.ddl:19:21--19:38
+                    -- ./Det009.ddl:25:3--26:11
+                    -- ./Det009.ddl:23:15--23:27
+                    -- ./Det009.ddl:23:15--23:27
+                    -- ./Det009.ddl:23:15--23:35
+                    -- ./Det009.ddl:25:3--25:9
+                    -- DETCALL 
+                    -- ./Det009.ddl:52:16--52:31
+                    -- ./Det009.ddl:52:21--52:25
+                    -- ./Det009.ddl:52:21--52:31
+                    -- ./Det009.ddl:23:15--23:22
+                    -- DETCALL 
+                    -- ./Det009.ddl:52:27--52:31
+                    -- ./Det009.ddl:52:27--52:31
+                    -- ./Det009.ddl:23:15--23:35
+                    case _31 of
+                      True ->
+                        -- ./Det009.ddl:23:15--23:35
+                        pure ()
+                      False ->
+                        fail_sys @() "Pattern match failure"
+                    _39 <- -- DETCALL 
+                           -- ./Det009.ddl:19:21--19:38
+                           -- ./Det009.ddl:25:3--26:11
+                           -- ./Det009.ddl:26:3--26:11
+                           -- ./Det009.ddl:26:3--26:11
+                           Unsgned(e)
+                    -- ./Det009.ddl:19:3--19:38
+                    pure (tag rowsPerStrip @IFDEntry _39)
+               orelse
+                 -- ./Det009.ddl:21:3--21:28
+                 -- unknown
+                 -- ./Det009.ddl:21:3--21:28
+                 do let e = e
+                    let e = e
+                    let _28 = _x0
+                    let _29 = _x1
+                    let tag = jn_71(e, _28, _29)
+                    _33 <- -- ./Det009.ddl:39:12--39:30
+                           -- ./Det009.ddl:39:3--47:3
+                           -- ./Det009.ddl:38:3--47:3
+                           -- ./Det009.ddl:21:17--21:28
+                           -- DETCALL 
+                           -- ./Det009.ddl:52:16--52:31
+                           -- ./Det009.ddl:52:21--52:25
+                           -- ./Det009.ddl:52:21--52:31
+                           -- ./Det009.ddl:38:12--38:19
+                           -- DETCALL 
+                           -- ./Det009.ddl:52:27--52:31
+                           -- ./Det009.ddl:52:27--52:31
+                           -- ./Det009.ddl:39:12--39:19
+                           Word16(e)
+                    let format = cast @(Word 64) _33
+                    -- ./Det009.ddl:37:20--47:3
+                    -- ./Det009.ddl:39:12--39:30
+                    -- ./Det009.ddl:39:3--47:3
+                    -- ./Det009.ddl:38:3--47:3
+                    -- ./Det009.ddl:21:17--21:28
+                    -- DETCALL 
+                    -- ./Det009.ddl:52:16--52:31
+                    -- ./Det009.ddl:52:21--52:25
+                    -- ./Det009.ddl:52:21--52:31
+                    -- ./Det009.ddl:38:12--38:19
+                    -- DETCALL 
+                    -- ./Det009.ddl:52:27--52:31
+                    -- ./Det009.ddl:52:27--52:31
+                    -- ./Det009.ddl:39:12--39:30
+                    let _40 = IFDUnknown {tag = tag, format = format}
+                    -- ./Det009.ddl:21:3--21:28
+                    pure (tag unknown @IFDEntry _40)
+ 
+-- entry pont
+-- ./Det009.ddl:3:1--7:3
+proc Main() : IFDEntry =
+  -- ./Det009.ddl:4:4--5:12
+  do e <- -- ./Det009.ddl:4:8--4:13
+          Endian()
+     -- ./Det009.ddl:5:3--5:12
+     -- ./Det009.ddl:5:3--5:12
+     IFDEntry(e)

--- a/tests/determinize/Det010.ddl
+++ b/tests/determinize/Det010.ddl
@@ -1,0 +1,6 @@
+-- testing avoiding state explosion
+
+def Main =
+  First
+    block $$ = $[0xFE]; $[0x01]
+    $[ !0xFE ]

--- a/tests/determinize/Det010.ddl.stdout
+++ b/tests/determinize/Det010.ddl.stdout
@@ -1,0 +1,22 @@
+module Det010
+ 
+--- Imports:
+ 
+--- Type defs:
+ 
+--- Rules:
+ 
+Det010.Main : Grammar (uint 8) =
+  Choose biased
+    { do ($$ : uint 8) <- Match {0xFE}
+         @Match {0x01}
+         pure $$
+    | Match (!{0xFE})
+    }
+ 
+Det010.Main_ : Grammar {} =
+  Choose biased
+    { do @Match {0xFE}
+         @Match {0x01}
+    | @Match (!{0xFE})
+    }

--- a/tests/determinize/Det010.test
+++ b/tests/determinize/Det010.test
@@ -1,0 +1,4 @@
+dump
+Det010.ddl
+--core
+--determinize

--- a/tests/determinize/Det010.test.stdout
+++ b/tests/determinize/Det010.test.stdout
@@ -1,0 +1,24 @@
+module DaedalusMain where
+ 
+ 
+-------------
+ 
+-- entry pont
+-- ./Det010.ddl:3:1--6:14
+proc Main() : Word 8 =
+  -- ./Det010.ddl:4:3--6:14
+  -- DETERMINIZE 1 Fully
+  do _x0 <- match1 { ... }
+     case _x0 of
+       254 ->
+         -- ./Det010.ddl:5:11--5:12
+         -- ./Det010.ddl:5:16--5:22
+         do let $$ = 254 @(Word 8)
+            -- ./Det010.ddl:5:25--5:12
+            -- ./Det010.ddl:5:25--5:31
+            match1_ { 1 @(Word 8) }
+            -- ./Det010.ddl:5:11--5:12
+            pure $$
+       _ ->
+         -- ./Det010.ddl:6:5--6:14
+         pure _x0


### PR DESCRIPTION
The determinization was only handling grammar calls with no arguments, this PR upgrades the determinization so that it can process some limited form of grammar calls with arguments. An example of what it is capable is provided in the unit test `Det009.ddl`.
 This change uncovered a state explosion caused by `UInt8` being always expanded into a case on 256 characters. Therefore this PR also include changes to the algorithm so that it produce a compact resulting grammar that does not explode the 256 characters when encountering `UInt8`. These changes should facilitate future changes to handle more complex patterns for matching a character.