### PR TITLE
Avoid undefined behavior when an array is uninitialized

### DIFF
--- a/rts-c/ddl/array.h
+++ b/rts-c/ddl/array.h
@@ -145,6 +145,9 @@ public:
 
 
   T* borrowData() const {
+    if(ptr == nullptr) {
+      return nullptr;
+    }
     return (T*)&ptr->data;
   }
 


### PR DESCRIPTION
Fixes the null pointer dereference described in #289.