### PR TITLE
daedalus: make Options carry an optional optParserDDL

### DIFF
--- a/exe/CommandLine.hs
+++ b/exe/CommandLine.hs
@@ -40,7 +40,7 @@ data Backend = UseInterp | UseCore | UseVM | UsePGen Bool
 
 data Options =
   Options { optCommand   :: Command
-          , optParserDDL :: FilePath
+          , optParserDDL :: Maybe FilePath
           , optEntries   :: [String]
           , optBackend   :: Backend
           , optForceUTF8 :: Bool
@@ -74,7 +74,7 @@ data Options =
 defaultOptions :: Options
 defaultOptions =
   Options { optCommand   = DumpTC
-          , optParserDDL = ""
+          , optParserDDL = Nothing
           , optBackend   = UseInterp
           , optEntries   = []
           , optForceUTF8 = True
@@ -291,7 +291,7 @@ cmdJsonToHtmlOptions = (\o -> o { optCommand = JStoHTML }, opts)
               [ helpOption
               ]
           , progParamDocs = [ ("FILE", "The JSON file to process.") ]
-          , progParams    = \s o -> Right o { optParserDDL = s }
+          , progParams    = \s o -> Right o { optParserDDL = Just s }
           }
 
 cmdCompileHSOptions :: CommandSpec
@@ -513,7 +513,7 @@ helpOption =
 optWithDDL :: OptSpec Options
 optWithDDL = optSpec
   { progParamDocs = [ ("FILE", "The DDL specification to process.") ]
-  , progParams    = \s o -> Right o { optParserDDL = s }
+  , progParams    = \s o -> Right o { optParserDDL = Just s }
   }
 
 colonSplitText :: String -> (Text, Maybe String)


### PR DESCRIPTION
This change makes it so that rather than using an empty string to indicate "no optParserDDL value", we use Nothing. This forces the uses of optParserDDL to deal better with the case where the argument is missing; previously, an invalid command like 'daedalus run' would emit this error:
```
  Missing module ``
  Searched paths:
    * ./
```
That error obscures the basic problem, which is that the implementation expected a DDL file argument after 'run'. This change makes it so that when the filename is missing, a GetOptException is raised instead, which ought to be consistent with a few other places where late-stage input errors are handled in a similar way.