### PR TITLE
quick nvim LSP integration

### DIFF
--- a/daedalus-language-server/README
+++ b/daedalus-language-server/README
@@ -3,3 +3,17 @@ This directory contains an LSP server for DaeDaLus.
 For instructions on how to use this server with VS Code, please look at
 the README in `syntax-highlight/vscode-daedalus`
 
+To use this with neovim, you will need the `lspconfig` plugin; then an LSP
+config for daedalus is available in the `nvim` directory. For example, with the
+`vim-plug` package manager, you would put something like this in `init.vim`:
+
+    call plug#begin()
+    Plug 'neovim/nvim-lspconfig'
+    Plug 'GaloisInc/daedalus', {'rtp': 'daedalus-language-server/nvim'}
+    call plug#end()
+    lua lsp.daedalus.setup {}
+
+Don't forget to `cabal install` and make sure the `daedalus-language-server`
+executable is on your `$PATH`. See the [`lspconfig`
+documentation](https://github.com/neovim/nvim-lspconfig#Suggested-configuration)
+for suggestions on setting up keybindings.

--- a/daedalus-language-server/nvim/ftdetect/daedalus.vim
+++ b/daedalus-language-server/nvim/ftdetect/daedalus.vim
@@ -1,0 +1,1 @@
+au BufNewFile,BufRead *.ddl set filetype=daedalus

--- a/daedalus-language-server/nvim/lua/lspconfig/server_configurations/daedalus.lua
+++ b/daedalus-language-server/nvim/lua/lspconfig/server_configurations/daedalus.lua
@@ -1,0 +1,17 @@
+local util = require 'lspconfig.util'
+
+return {
+    default_config = {
+        cmd = { 'daedalus-language-server' },
+        filetypes = { 'daedalus' },
+        root_dir = function(filepath)
+            return util.path.dirname(filepath)
+        end,
+    },
+    docs = {
+        description = [[
+https://github.com/GaloisInc/daedalus/tree/master/daedalus-language-server
+
+Daedalus Language Server]],
+    },
+}


### PR DESCRIPTION
Here's a bare-bones config for using the daedalus language server in nvim, compatible with the popular lspconfig package for managing LSP settings. There's also a blurb in the documentation about how to use it.