### PR TITLE
Remove quoted content-length

### DIFF
--- a/http-talos/http/HTTP-1.1.ddl
+++ b/http-talos/http/HTTP-1.1.ddl
@@ -381,7 +381,7 @@ def HTTP_field: HTTP_field_u =
       --
       -- https://www.rfc-editor.org/rfc/rfc9110#section-5.5-12
       -- https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.5
-      let values = SepBy1 (MaybeQuoted PositiveNum64) { HTTP_OWS; $[',']; HTTP_OWS }
+      let values = SepBy1 (PositiveNum64) { HTTP_OWS; $[',']; HTTP_OWS }
       let first = Head values
       map (val in values) (val == first) is true
       first > 0 is true
@@ -430,7 +430,7 @@ def HTTP_field: HTTP_field_u =
     --      -- https://www.rfc-editor.org/rfc/rfc9110#section-5.5-12
     --      -- https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.5
     --      block
-    --        let values = SepBy1 (MaybeQuoted PositiveNum64) { HTTP_OWS; $[',']; HTTP_OWS }
+    --        let values = SepBy1 (PositiveNum64) { HTTP_OWS; $[',']; HTTP_OWS }
     --        let first = Head values
     --        let checked = for (result = first; val in values)
     --                        block

--- a/http-talos/http/HTTP-1.1.ddl
+++ b/http-talos/http/HTTP-1.1.ddl
@@ -381,7 +381,7 @@ def HTTP_field: HTTP_field_u =
       --
       -- https://www.rfc-editor.org/rfc/rfc9110#section-5.5-12
       -- https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.5
-      let values = SepBy1 (PositiveNum64) { HTTP_OWS; $[',']; HTTP_OWS }
+      let values = SepBy1 PositiveNum64 { HTTP_OWS; $[',']; HTTP_OWS }
       let first = Head values
       map (val in values) (val == first) is true
       first > 0 is true
@@ -430,7 +430,7 @@ def HTTP_field: HTTP_field_u =
     --      -- https://www.rfc-editor.org/rfc/rfc9110#section-5.5-12
     --      -- https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.5
     --      block
-    --        let values = SepBy1 (PositiveNum64) { HTTP_OWS; $[',']; HTTP_OWS }
+    --        let values = SepBy1 PositiveNum64 { HTTP_OWS; $[',']; HTTP_OWS }
     --        let first = Head values
     --        let checked = for (result = first; val in values)
     --                        block


### PR DESCRIPTION
When I try to feed the generated examples to my parsers, they complain because the Content-Length values are quoted.
`HTTP.ddl` says this:
```
      -- NOTE: the specification permits all field values to be
      -- either tokens or quoted strings. This handles both. The
      -- specification also states that a Content-Length field is
      -- valid if it is a comma-separated list of numbers, all of
      -- which take the same value. We also handle that case here.
```

The relevant portion of the RFC says this:
> Many fields (such as [Content-Type](https://www.rfc-editor.org/rfc/rfc9110#field.content-type), defined in [Section 8.3](https://www.rfc-editor.org/rfc/rfc9110#field.content-type)) use a common syntax for parameters that allows both unquoted (token) and quoted (quoted-string) syntax for a parameter value ([Section 5.6.6](https://www.rfc-editor.org/rfc/rfc9110#parameter)). Use of common syntax allows recipients to reuse existing parser components. When allowing both forms, the meaning of a parameter value ought to be the same whether it was received as a token or a quoted string.

As far as I can tell, this isn't a universal statement about all `field-value`s; it's just saying that some headers, including `Content-Type`, can have either quoted or unquoted values.
My understanding is that `Content-Length` can't have a quoted value, so this PR removes a couple of `MaybeQuoted`s.