### PR TITLE
BUGFIX: Let terms in CFG creation

### DIFF
--- a/daedalus-core/src/Daedalus/Core/CFG.hs
+++ b/daedalus-core/src/Daedalus/Core/CFG.hs
@@ -138,8 +138,8 @@ cfgG m_x exitN (WithNodeID inN _anns g) =
     Do_ lhs rhs   -> goDo Nothing lhs rhs
     Do  n lhs rhs -> goDo (Just n) lhs rhs
     Let n e rhs   -> do
-      rhsN <- cfgG (Just n) exitN rhs
-      emitNode (CSimple m_x (CPure e) rhsN)
+      rhsN <- cfgG m_x exitN rhs
+      emitNode (CSimple (Just n) (CPure e) rhsN)
 
     OrBiased lhs rhs   -> goOr True lhs rhs
     OrUnbiased lhs rhs -> goOr False lhs rhs


### PR DESCRIPTION
Fixes what I suspect is a bug in how `Let` terms are translated to CFG nodes, where the bound name is inserted into the wrong node(s).

Seems like a benign bug though -- I think `Let` terms are translated to `Do` terms somewhere upstream, because I wasn't able to reproduce the bug in practice, and I confirmed that this code is not executed when processing a test file containing `let` statements.