### PR TITLE
Remove broken sexp test

### DIFF
--- a/tests/sexp/sexp-mutrec.sexp
+++ b/tests/sexp/sexp-mutrec.sexp
@@ -1,1 +1,0 @@
-((foo bar baz ( big ) ) )

--- a/tests/sexp/sexp-mutrec.test
+++ b/tests/sexp/sexp-mutrec.test
@@ -1,3 +1,0 @@
-run
-../../formats/sexp-mutrec.ddl
---input=sexp-mutrec.sexp

--- a/tests/sexp/sexp-mutrec.test.stdout
+++ b/tests/sexp/sexp-mutrec.test.stdout
@@ -1,8 +1,0 @@
---- Found 1 results:
-{sexp: [ {sexp: [ {symbol: "foo"}
-                , {symbol: "bar"}
-                , {symbol: "baz"}
-                , {sexp: [ {symbol: "big"}
-                         ]}
-                ]}
-       ]}


### PR DESCRIPTION
This test used to test formats/sexp-mutrec.ddl, which was removed in 635719f.